### PR TITLE
feat: 에코 스톡 포트폴리오 조회 추가

### DIFF
--- a/src/main/java/org/phoenix/planet/controller/MemberStockInfoController.java
+++ b/src/main/java/org/phoenix/planet/controller/MemberStockInfoController.java
@@ -3,13 +3,12 @@ package org.phoenix.planet.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.phoenix.planet.annotation.LoginMemberId;
+import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
 import org.phoenix.planet.dto.eco_stock.request.SellStockRequest;
 import org.phoenix.planet.service.eco_stock.EcoStockService;
+import org.phoenix.planet.service.eco_stock.MemberStockInfoService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @Slf4j
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/portfolio")
 public class MemberStockInfoController {
 
+    private final MemberStockInfoService memberStockInfoService;
     private final EcoStockService ecoStockService;
 
     @PostMapping("/stock/sell")
@@ -27,5 +27,17 @@ public class MemberStockInfoController {
         ecoStockService.sellStock(loginMemberId, sellStockRequest);
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/summary")
+    public ResponseEntity<?> getUserInfo(@RequestParam("ecoStockId") Long ecoStockId, @LoginMemberId Long loginMemberId) {
+
+        log.info("get user info:{} {}", ecoStockId, loginMemberId);
+
+        MemberStockInfo memberStockInfo = memberStockInfoService.findPersonalStockInfoById(loginMemberId, ecoStockId);
+
+        log.info("get user info:{}", memberStockInfo);
+
+        return ResponseEntity.ok().body(memberStockInfo);
     }
 }

--- a/src/main/java/org/phoenix/planet/dto/eco_stock/raw/MemberStockInfo.java
+++ b/src/main/java/org/phoenix/planet/dto/eco_stock/raw/MemberStockInfo.java
@@ -1,0 +1,12 @@
+package org.phoenix.planet.dto.eco_stock.raw;
+
+public record MemberStockInfo(
+
+        Long memberStockInfoId,
+        Long memberId,
+        Long ecoStockId,
+        Integer currentTotalQuantity,
+        Long currentTotalAmount,
+        Integer point
+) {
+}

--- a/src/main/java/org/phoenix/planet/mapper/MemberStockInfoMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberStockInfoMapper.java
@@ -1,0 +1,10 @@
+package org.phoenix.planet.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
+
+@Mapper
+public interface MemberStockInfoMapper {
+    MemberStockInfo findPersonalStockInfoById(@Param("memberId") Long memberId, @Param("ecoStockId") Long ecoStockId);
+}

--- a/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoService.java
+++ b/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoService.java
@@ -1,0 +1,7 @@
+package org.phoenix.planet.service.eco_stock;
+
+import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
+
+public interface MemberStockInfoService {
+    MemberStockInfo findPersonalStockInfoById(Long loginMemberId, Long ecoStockId);
+}

--- a/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoServiceImpl.java
@@ -1,0 +1,20 @@
+package org.phoenix.planet.service.eco_stock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
+import org.phoenix.planet.mapper.MemberStockInfoMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberStockInfoServiceImpl implements MemberStockInfoService {
+
+    private final MemberStockInfoMapper memberStockInfoMapper;
+
+    @Override
+    public MemberStockInfo findPersonalStockInfoById(Long memberId, Long ecoStockId) {
+        return memberStockInfoMapper.findPersonalStockInfoById(memberId, ecoStockId);
+    }
+}

--- a/src/main/resources/mapper/eco_stock/member_stock_info.xml
+++ b/src/main/resources/mapper/eco_stock/member_stock_info.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.phoenix.planet.mapper.MemberStockInfoMapper">
+
+    <select id="findPersonalStockInfoById"
+            resultType="org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo">
+        SELECT
+        msi.MEMBER_STOCK_INFO_ID as memberStockInfoId,
+        m.MEMBER_ID as memberId,
+        msi.ECO_STOCK_ID as ecoStockId,
+        COALESCE(msi.CURRENT_TOTAL_QUANTITY, 0) as currentTotalQuantity,
+        COALESCE(msi.CURRENT_TOTAL_AMOUNT, 0) as currentTotalAmount,
+        m.POINT as point
+        FROM MEMBER m
+        LEFT JOIN MEMBER_STOCK_INFO msi
+        ON m.MEMBER_ID = msi.MEMBER_ID
+        AND msi.ECO_STOCK_ID = #{ecoStockId}
+        WHERE m.MEMBER_ID = #{memberId}
+    </select>
+</mapper>


### PR DESCRIPTION
# 📊 에코스톡 포트폴리오 조회 기능 추가

---

## 📌 개요  
사용자별 에코스톡 보유 현황을 조회할 수 있는 포트폴리오 API를 구현했습니다.

---

## 🛠 작업 내용

### ✅ 사용자 포트폴리오 조회 API 구현
- 로그인된 사용자 기준 보유 중인 에코스톡 리스트 반환
- 종목별 수량, 평균 구매가, 총 평가 금액 등 포함

### ✅ DTO 및 Service 레이어 구성
- `EcoStockPortfolioResponse` 등 응답 객체 정의
- Repository에서 join 및 계산 처리
