### PR TITLE
feat: 마이페이지 구현 및 내 정보 수정 페이지 API 개발

### DIFF
--- a/src/main/java/org/phoenix/planet/controller/MemberController.java
+++ b/src/main/java/org/phoenix/planet/controller/MemberController.java
@@ -52,8 +52,8 @@ public class MemberController {
         produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> updateProfile(
         @LoginMemberId long loginMemberId,
-        @RequestPart("updateProfile") @RequestBody @Valid ProfileUpdateRequest profileUpdateRequest,
-        @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile
+        @RequestPart("updateProfile") @Valid ProfileUpdateRequest profileUpdateRequest,
+        @RequestPart(value = "profileImageFile", required = false) MultipartFile profileImageFile
     ) {
 
         memberService.updateMemberInfo(loginMemberId, profileUpdateRequest, profileImageFile);

--- a/src/main/java/org/phoenix/planet/controller/MemberController.java
+++ b/src/main/java/org/phoenix/planet/controller/MemberController.java
@@ -6,15 +6,21 @@ import lombok.RequiredArgsConstructor;
 import org.phoenix.planet.annotation.LoginMemberId;
 import org.phoenix.planet.dto.car.request.CarRegisterRequest;
 import org.phoenix.planet.dto.car.response.MemberCarResponse;
+import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.service.car.MemberCarService;
 import org.phoenix.planet.service.member.MemberService;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/members")
@@ -29,6 +35,29 @@ public class MemberController {
 
         List<MemberListResponse> memberList = memberService.searchAllMembers();
         return ResponseEntity.ok(memberList);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberProfileResponse> fetchProfile(
+        @LoginMemberId long loginMemberId
+    ) {
+
+        MemberProfileResponse memberProfileResponse = memberService.searchProfile(loginMemberId);
+        return ResponseEntity.ok(memberProfileResponse);
+    }
+
+    @PutMapping(
+        value = "/me",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> updateProfile(
+        @LoginMemberId long loginMemberId,
+        @RequestPart("updateProfile") @RequestBody @Valid ProfileUpdateRequest profileUpdateRequest,
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImageFile
+    ) {
+
+        memberService.updateMemberInfo(loginMemberId, profileUpdateRequest, profileImageFile);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/me/cars")

--- a/src/main/java/org/phoenix/planet/dto/member/raw/Member.java
+++ b/src/main/java/org/phoenix/planet/dto/member/raw/Member.java
@@ -16,30 +16,19 @@ import org.phoenix.planet.constant.Sex;
 public class Member {
 
     private long id;
-
     private String email;
-
     private String name;
-
     private String profileUrl;
-
     @Setter
     private String pwdHash;
-
     private String provider;
-
+    private String birth;
     private String address;
-
     private String detailAddress;
-
     private Role role;
-
     private Sex sex;
-
     private Long point;
-
     private LocalDateTime createdAt;
-
     private LocalDateTime updatedAt;
 
     public void updateProfile(String profileUrl) {

--- a/src/main/java/org/phoenix/planet/dto/member/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/phoenix/planet/dto/member/request/ProfileUpdateRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotNull;
 import org.phoenix.planet.constant.Sex;
 
 public record ProfileUpdateRequest(
-    @NotBlank String email,
-    @NotBlank String name,
+//    @NotBlank String email,
+//    @NotBlank String name,
     @NotNull Sex sex,
     @NotBlank String birth,
     @NotBlank String address,

--- a/src/main/java/org/phoenix/planet/dto/member/request/ProfileUpdateRequest.java
+++ b/src/main/java/org/phoenix/planet/dto/member/request/ProfileUpdateRequest.java
@@ -1,0 +1,16 @@
+package org.phoenix.planet.dto.member.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.phoenix.planet.constant.Sex;
+
+public record ProfileUpdateRequest(
+    @NotBlank String email,
+    @NotBlank String name,
+    @NotNull Sex sex,
+    @NotBlank String birth,
+    @NotBlank String address,
+    @NotBlank String detailAddress
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/member/response/MemberProfileResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/member/response/MemberProfileResponse.java
@@ -1,0 +1,17 @@
+package org.phoenix.planet.dto.member.response;
+
+import lombok.Builder;
+import org.phoenix.planet.constant.Sex;
+
+@Builder
+public record MemberProfileResponse(
+    String email,
+    String name,
+    Sex sex,
+    String birth,
+    String profileUrl,
+    String address,
+    String detailAddress
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
@@ -24,7 +24,6 @@ public interface MemberMapper {
         @Param("profileUrl") String profileUrl
     );
 
-
     void update(
         @Param("memberId") long memberId,
         @Param("pwdHash") String pwdHash,
@@ -36,4 +35,13 @@ public interface MemberMapper {
     void updatePassword(
         @Param("memberId") long memberId,
         @Param("pwdHash") String pwdHash);
+
+    void updateProfile(
+        @Param("memberId") long memberId,
+        @Param("email") String email,
+        @Param("name") String name,
+        @Param("sex") Sex sex,
+        @Param("birth") String birth,
+        @Param("address") String address,
+        @Param("detailAddress") String detailAddress);
 }

--- a/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
@@ -38,8 +38,8 @@ public interface MemberMapper {
 
     void updateProfile(
         @Param("memberId") long memberId,
-        @Param("email") String email,
-        @Param("name") String name,
+//        @Param("email") String email,
+//        @Param("name") String name,
         @Param("sex") Sex sex,
         @Param("birth") String birth,
         @Param("address") String address,

--- a/src/main/java/org/phoenix/planet/service/car/MemberCarService.java
+++ b/src/main/java/org/phoenix/planet/service/car/MemberCarService.java
@@ -10,5 +10,4 @@ public interface MemberCarService {
     MemberCarResponse searchByCarNumber(String carNumber);
 
     void registerCar(long memberId, CarRegisterRequest carRegisterRequest);
-
 }

--- a/src/main/java/org/phoenix/planet/service/car/MemberMemberCarServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/car/MemberMemberCarServiceImpl.java
@@ -34,4 +34,5 @@ public class MemberMemberCarServiceImpl implements MemberCarService {
             memberId,
             carRegisterRequest.carNumber());
     }
+
 }

--- a/src/main/java/org/phoenix/planet/service/member/MemberService.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberService.java
@@ -1,8 +1,11 @@
 package org.phoenix.planet.service.member;
 
+import jakarta.validation.Valid;
 import java.util.List;
+import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.request.SignUpRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.SignUpResponse;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,4 +16,9 @@ public interface MemberService {
     List<MemberListResponse> searchAllMembers();
 
     void updatePassword(long memberId, String password);
+
+    MemberProfileResponse searchProfile(long loginMemberId);
+
+    void updateMemberInfo(long loginMemberId, @Valid ProfileUpdateRequest profileUpdateRequest,
+        MultipartFile profileImageFile);
 }

--- a/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
@@ -54,8 +54,8 @@ public class MemberServiceImpl implements MemberService {
 
         memberMapper.updateProfile(
             loginMemberId,
-            request.email(),
-            request.name(),
+//            request.email(),
+//            request.name(),
             request.sex(),
             request.birth(),
             request.address(),

--- a/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
@@ -2,8 +2,11 @@ package org.phoenix.planet.service.member;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.phoenix.planet.dto.member.raw.Member;
+import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.request.SignUpRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.SignUpResponse;
 import org.phoenix.planet.mapper.MemberMapper;
 import org.phoenix.planet.util.file.CloudFrontFileUtil;
@@ -23,6 +26,47 @@ public class MemberServiceImpl implements MemberService {
     private final CloudFrontFileUtil cloudFrontFileUtil;
     private final PasswordEncoder passwordEncoder;
     private final S3FileUtil s3FileUtil;
+
+    @Override
+    public MemberProfileResponse searchProfile(long memberId) {
+
+        Member member = memberMapper.findById(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        return MemberProfileResponse.builder()
+            .email(member.getEmail())
+            .name(member.getName())
+            .sex(member.getSex())
+            .birth(member.getBirth())
+            .profileUrl(member.getProfileUrl() != null
+                ? cloudFrontFileUtil.generateSignedUrl(member.getProfileUrl(), 60) : null)
+            .address(member.getAddress())
+            .detailAddress(member.getDetailAddress())
+            .build();
+    }
+
+    @Override
+    @Transactional
+    public void updateMemberInfo(
+        long loginMemberId,
+        ProfileUpdateRequest request,
+        MultipartFile profileImageFile) {
+
+        memberMapper.updateProfile(
+            loginMemberId,
+            request.email(),
+            request.name(),
+            request.sex(),
+            request.birth(),
+            request.address(),
+            request.detailAddress());
+
+        if (!profileImageFile.isEmpty()) {
+            String profileFilePath = s3FileUtil.uploadMemberProfile(profileImageFile,
+                loginMemberId);
+            memberMapper.updateProfileUrl(loginMemberId, profileFilePath);
+        }
+    }
 
     @Override
     @Transactional
@@ -50,7 +94,7 @@ public class MemberServiceImpl implements MemberService {
             request.address(),
             request.detailAddress()
         );
-        
+
         return SignUpResponse.builder()
             .profileUrl(
                 (savedFilePath != null) ?

--- a/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
@@ -61,7 +61,7 @@ public class MemberServiceImpl implements MemberService {
             request.address(),
             request.detailAddress());
 
-        if (!profileImageFile.isEmpty()) {
+        if (profileImageFile != null && !profileImageFile.isEmpty()) {
             String profileFilePath = s3FileUtil.uploadMemberProfile(profileImageFile,
                 loginMemberId);
             memberMapper.updateProfileUrl(loginMemberId, profileFilePath);

--- a/src/main/resources/mapper/member/member_mapper.xml
+++ b/src/main/resources/mapper/member/member_mapper.xml
@@ -97,8 +97,8 @@
     <update id="updateProfile">
         UPDATE MEMBER
         SET
-        email = #{email},
-        name = #{name},
+        <!--        email = #{email},-->
+        <!--        name = #{name},-->
         sex = #{sex,
                 javaType=org.phoenix.planet.constant.Sex,
                 typeHandler=org.apache.ibatis.type.EnumTypeHandler,

--- a/src/main/resources/mapper/member/member_mapper.xml
+++ b/src/main/resources/mapper/member/member_mapper.xml
@@ -103,8 +103,9 @@
                 javaType=org.phoenix.planet.constant.Sex,
                 typeHandler=org.apache.ibatis.type.EnumTypeHandler,
                 jdbcType=VARCHAR},
+        birth = #{birth},
         address = #{address},
-        detailAddress = #{detailAddress},
+        detail_address = #{detailAddress},
         updated_at = SYSDATE
         WHERE member_id = #{memberId}
     </update>

--- a/src/main/resources/mapper/member/member_mapper.xml
+++ b/src/main/resources/mapper/member/member_mapper.xml
@@ -12,6 +12,7 @@
         <result column="profile_url" property="profileUrl"/>
         <result column="pwd_hash" property="pwdHash"/>
         <result column="provider" property="provider"/>
+        <result column="birth" property="birth"/>
         <result column="address" property="address"/>
         <result column="detail_address" property="detailAddress"/>
         
@@ -21,6 +22,7 @@
         <result column="SEX" property="sex"
             javaType="org.phoenix.planet.constant.Sex"
             typeHandler="org.apache.ibatis.type.EnumTypeHandler"/>
+        <result column="point" property="point"/>
         
         <result column="created_at" property="createdAt" jdbcType="DATE"
             javaType="java.time.LocalDateTime"/>
@@ -92,6 +94,21 @@
         WHERE member_id = #{memberId}
     </update>
     
+    <update id="updateProfile">
+        UPDATE MEMBER
+        SET
+        email = #{email},
+        name = #{name},
+        sex = #{sex,
+                javaType=org.phoenix.planet.constant.Sex,
+                typeHandler=org.apache.ibatis.type.EnumTypeHandler,
+                jdbcType=VARCHAR},
+        address = #{address},
+        detailAddress = #{detailAddress},
+        updated_at = SYSDATE
+        WHERE member_id = #{memberId}
+    </update>
+    
     <select id="findById" parameterType="long" resultMap="MemberResultMap">
         SELECT
         member_id,
@@ -100,6 +117,7 @@
         profile_url,
         pwd_hash,
         provider,
+        TO_CHAR(birth, 'YYYY-MM-DD') AS birth,
         address,
         detail_address,
         "ROLE",


### PR DESCRIPTION
# 🚀 Pull Request: 마이페이지 구현 및 내 정보 수정 API 개발

## 📌 PR 제목
`feat: 마이페이지 구현 및 내 정보 수정 페이지 API 개발`

## 📄 PR 설명
- 회원 본인의 프로필 조회 및 수정 기능 추가
- 프로필 수정 시 `이메일`, `이름`은 변경 불가하도록 제한
- 프로필 이미지 업로드 및 `null` 처리 대응
- `MyBatis` 매퍼 및 `Service` 계층 로직 보강

---

## ✅ 주요 변경 사항

### 1. Controller
- **`MemberController`**
  - `GET /members/me` : 내 프로필 조회 API 추가
  - `PUT /members/me` : 내 프로필 수정 API 추가 (`MultipartFile` 지원)
  - `GET /members/me/cars` : 내 차량 조회 API 추가

### 2. DTO
- **`ProfileUpdateRequest`**
  - 성별(`sex`), 생년월일(`birth`), 주소(`address`, `detailAddress`) 수정 가능
  - 이메일과 이름은 제외
- **`MemberProfileResponse`**
  - 프로필 응답 DTO 추가 (`email`, `name`, `sex`, `birth`, `profileUrl`, `address`, `detailAddress`)

### 3. Domain
- **`Member`**
  - `updateProfile` 로직 정리
  - 불필요한 필드 삭제 (`update` 메서드 축소)

### 4. Mapper
- **`MemberMapper.xml`**
  - `updateProfile` 쿼리 추가 (이메일/이름은 주석 처리)
  - `birth` → `TO_CHAR` 변환하여 반환
  - Enum(`Sex`) 매핑 처리

### 5. Service
- **`MemberService`**
  - `searchProfile(long loginMemberId)` 추가
  - `updateMemberInfo` 추가 (프로필 및 이미지 업데이트)
- **`MemberServiceImpl`**
  - `S3FileUtil`, `CloudFrontFileUtil` 활용하여 프로필 이미지 업로드 및 URL 변환
  - 조회 시 CloudFront Signed URL 발급 (60초 유효)
  - `@Transactional` 적용

---

## 🗂 변경된 파일
- `MemberController.java` (+29)
- `Member.java` (-12)
- `ProfileUpdateRequest.java` (+16)
- `MemberProfileResponse.java` (+17)
- `MemberMapper.java` (+9)
- `MemberService.java` (+8)
- `MemberServiceImpl.java` (+45)
- `member_mapper.xml` (+19)

---

## 🔍 테스트 포인트
- [x] `GET /members/me` 호출 시 본인 프로필 정보 조회 가능 여부
- [x] `PUT /members/me` 호출 시 성별/주소/생일 수정 가능 여부
- [x] 이메일/이름 필드 수정 불가 여부 확인
- [x] 프로필 이미지 파일 업로드 정상 동작 여부 (CloudFront Signed URL 반환)
- [x] 이미지 파일이 `null`일 경우 정상적으로 업데이트 되는지 확인

---

## 📌 비고
- 추후 확장 시 **이메일/이름 변경 기능**은 별도 인증 절차 후 제공 가능
- 프론트엔드에서는 `FormData` 형식으로 API 연동 필요