### PR TITLE
Feat/scrum 104 결제 전체 취소 api 구현

### DIFF
--- a/src/main/java/org/phoenix/planet/constant/OrderStatus.java
+++ b/src/main/java/org/phoenix/planet/constant/OrderStatus.java
@@ -12,7 +12,8 @@ public enum OrderStatus {
     SHIPPED("배송 중"),
     COMPLETED("배송 완료"),
     ALL_CANCELLED("전체 취소"),
-    PARTIAL_CANCELLED("부분 취소")
+    PARTIAL_CANCELLED("부분 취소"),
+    DONE("구매 확정")
     ;
 
     private final String value;

--- a/src/main/java/org/phoenix/planet/constant/PaymentError.java
+++ b/src/main/java/org/phoenix/planet/constant/PaymentError.java
@@ -28,9 +28,16 @@ public enum PaymentError {
     DELIVERY_INFO_REQUIRED(HttpStatus.BAD_REQUEST,"일반 배송 주문의 경우 배송 정보는 필수입니다."),
     PICKUP_INFO_REQUIRED(HttpStatus.BAD_REQUEST,"픽업 배송 주문의 경우 픽업 정보는 필수입니다."),
 
-    // 재고 및 포인트 오류
+    // 재고 및 포인트 등 오류
     INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+    STOCK_RESTORE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "재고 복구 처리에 실패했습니다."),
     INSUFFICIENT_POINTS(HttpStatus.BAD_REQUEST, "보유 포인트가 부족합니다."),
+    POINT_REFUND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "포인트 환불 처리에 실패했습니다."),
+    INVALID_POINT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 포인트 금액입니다."),
+    DONATION_CANCEL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "기부금 취소 처리에 실패했습니다."),
+    ORDER_STATUS_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "주문 상태 업데이트에 실패했습니다."),
+    INVALID_CANCEL_RESPONSE(HttpStatus.BAD_REQUEST, "취소 응답 정보가 올바르지 않습니다."),
+    PAYMENT_STATUS_UPDATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "결제 상태 업데이트에 실패했습니다."),
 
     // QR 코드 관련 오류
     QR_CODE_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "QR 코드 생성에 실패했습니다."),

--- a/src/main/java/org/phoenix/planet/controller/PaymentController.java
+++ b/src/main/java/org/phoenix/planet/controller/PaymentController.java
@@ -5,14 +5,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.phoenix.planet.annotation.LoginMemberId;
+import org.phoenix.planet.dto.payment.request.PaymentCancelReqeust;
 import org.phoenix.planet.dto.payment.request.PaymentConfirmRequest;
+import org.phoenix.planet.dto.payment.response.PaymentCancelResponse;
 import org.phoenix.planet.dto.payment.response.PaymentConfirmResponse;
 import org.phoenix.planet.service.payment.PaymentService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -32,6 +31,19 @@ public class PaymentController {
         PaymentConfirmResponse response = paymentService.confirmPayment(request, memberId);
 
         log.info("결제 승인 API 성공: orderId={}, memberId={}", request.orderId(), memberId);
+        return ResponseEntity.ok(response);
+    }
+    
+    @PostMapping("/{order-id}/cancel")
+    public ResponseEntity<PaymentCancelResponse> cancelOrder(
+        @PathVariable("order-id") Long orderHistoryId,
+        @RequestBody PaymentCancelReqeust request
+    ) {
+        log.info("주문 전체 취소 요청 - orderId: {}, reason: {}", orderHistoryId, request.cancelReason());
+
+        PaymentCancelResponse response = paymentService.cancelEntireOrder(orderHistoryId, request);
+        log.info("주문 전체 취소 완료 - orderId: {}, cancelAmount: {}", orderHistoryId, response.cancelAmount());
+
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/phoenix/planet/dto/payment/request/PaymentCancelReqeust.java
+++ b/src/main/java/org/phoenix/planet/dto/payment/request/PaymentCancelReqeust.java
@@ -1,0 +1,9 @@
+package org.phoenix.planet.dto.payment.request;
+
+/**
+ * 결제 취소 요청 DTO
+ */
+public record PaymentCancelReqeust(
+        String cancelReason  // 취소 사유
+) {
+}

--- a/src/main/java/org/phoenix/planet/dto/payment/request/TossPaymentsCancelRequest.java
+++ b/src/main/java/org/phoenix/planet/dto/payment/request/TossPaymentsCancelRequest.java
@@ -1,0 +1,7 @@
+package org.phoenix.planet.dto.payment.request;
+
+public record TossPaymentsCancelRequest(
+        Integer cancelAmount,  // Toss API는 Integer 사용
+        String cancelReason
+) {
+}

--- a/src/main/java/org/phoenix/planet/dto/payment/response/PaymentCancelResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/payment/response/PaymentCancelResponse.java
@@ -1,0 +1,52 @@
+package org.phoenix.planet.dto.payment.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDateTime;
+
+/**
+ * 결제 취소 응답 DTO
+ */
+public record PaymentCancelResponse(
+        boolean success,
+        String message,
+        Long orderId,
+        String orderNumber,
+        Long cancelAmount,
+        Long refundedPoints,
+
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime cancelledAt
+) {
+
+    public static PaymentCancelResponse success(
+            Long orderId,
+            String orderNumber,
+            Long cancelAmount,
+            Long refundedPoints,
+            String message
+    ) {
+        return new PaymentCancelResponse(
+                true,
+                message,
+                orderId,
+                orderNumber,
+                cancelAmount,
+                refundedPoints,
+                LocalDateTime.now()
+        );
+    }
+
+    public static PaymentCancelResponse error(String message) {
+        return new PaymentCancelResponse(
+                false,
+                message,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+}

--- a/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
@@ -47,4 +47,6 @@ public interface MemberMapper {
         @Param("address") String address,
         @Param("detailAddress") String detailAddress);
 
+    int restorePointsByMemberId(@Param("memberId") Long memberId, @Param("points") int points);
+
 }

--- a/src/main/java/org/phoenix/planet/mapper/OrderHistoryMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/OrderHistoryMapper.java
@@ -2,7 +2,10 @@ package org.phoenix.planet.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.phoenix.planet.constant.OrderStatus;
 import org.phoenix.planet.dto.order.raw.OrderHistory;
+
+import java.time.LocalDateTime;
 
 @Mapper
 public interface OrderHistoryMapper {
@@ -16,5 +19,13 @@ public interface OrderHistoryMapper {
     String findOrderNumberById(@Param("orderHistoryId") Long orderHistoryId);
 
     void updateQRCodeUrl(@Param("orderHistoryId") Long orderHistoryId, @Param("ecoDealQrUrl") String ecoDealQrUrl);
+
+    int updateDonationPrice(@Param("orderHistoryId") Long orderHistoryId, @Param("donationPrice") Long donationPrice);
+
+    int updateOrderStatus(
+            @Param("orderHistoryId") Long orderHistoryId,
+            @Param("orderStatus") OrderStatus orderStatus,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
 
 }

--- a/src/main/java/org/phoenix/planet/mapper/OrderProductMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/OrderProductMapper.java
@@ -1,11 +1,22 @@
 package org.phoenix.planet.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.phoenix.planet.constant.CancelStatus;
 import org.phoenix.planet.dto.order.raw.OrderProduct;
+
+import java.util.List;
 
 @Mapper
 public interface OrderProductMapper {
 
     void insert(OrderProduct orderProduct);
+
+    List<OrderProduct> findOrderProductsByOrderHistoryId(Long orderHistoryId);
+
+    void updateAllOrderProductsCancelStatus(
+            @Param("orderHistoryId") Long orderHistoryId,
+            @Param("cancelStatus") CancelStatus cancelStatus
+    );
 
 }

--- a/src/main/java/org/phoenix/planet/mapper/PaymentHistoryMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/PaymentHistoryMapper.java
@@ -2,7 +2,10 @@ package org.phoenix.planet.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.phoenix.planet.constant.PaymentStatus;
 import org.phoenix.planet.dto.payment.raw.PaymentHistory;
+
+import java.time.OffsetDateTime;
 
 @Mapper
 public interface PaymentHistoryMapper {
@@ -12,5 +15,7 @@ public interface PaymentHistoryMapper {
     PaymentHistory findByPaymentKey(@Param("paymentKey") String paymentKey);
 
     PaymentHistory findByOrderHistoryId(@Param("orderHistoryId") Long orderHistoryId);
+
+    int updatePaymentStatus(@Param("paymentId") Long paymentId, @Param("paymentStatus") PaymentStatus paymentStatus);
 
 }

--- a/src/main/java/org/phoenix/planet/mapper/ProductMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/ProductMapper.java
@@ -37,4 +37,7 @@ public interface ProductMapper {
     Integer getStock(@Param("productId") Long productId);
 
     List<ProductDetailResponse> getProductDetail(Long productId);
+
+    int restoreStock(@Param("productId") Long productId, @Param("quantity") int quantity);
+
 }

--- a/src/main/java/org/phoenix/planet/service/payment/PaymentService.java
+++ b/src/main/java/org/phoenix/planet/service/payment/PaymentService.java
@@ -1,10 +1,14 @@
 package org.phoenix.planet.service.payment;
 
+import org.phoenix.planet.dto.payment.request.PaymentCancelReqeust;
 import org.phoenix.planet.dto.payment.request.PaymentConfirmRequest;
+import org.phoenix.planet.dto.payment.response.PaymentCancelResponse;
 import org.phoenix.planet.dto.payment.response.PaymentConfirmResponse;
 
 public interface PaymentService {
 
     PaymentConfirmResponse confirmPayment(PaymentConfirmRequest request, Long memberId);
+
+    PaymentCancelResponse cancelEntireOrder(Long orderHistoryId, PaymentCancelReqeust request);
 
 }

--- a/src/main/java/org/phoenix/planet/service/payment/TossPaymentsClient.java
+++ b/src/main/java/org/phoenix/planet/service/payment/TossPaymentsClient.java
@@ -92,12 +92,10 @@ public class TossPaymentsClient {
             } else {
                 throw new TossPaymentsException("결제 정보 조회 응답이 올바르지 않습니다.");
             }
-
         } catch (HttpClientErrorException e) {
             log.error("TossPayments 클라이언트 오류: statusCode={}, responseBody={}",
                     e.getStatusCode(), e.getResponseBodyAsString());
             throw new TossPaymentsException("결제 정보 조회 중 오류가 발생했습니다: " + e.getResponseBodyAsString());
-
         } catch (Exception e) {
             log.error("TossPayments API 호출 중 예상치 못한 오류 발생", e);
             throw new TossPaymentsException("결제 정보 조회 중 시스템 오류가 발생했습니다.");
@@ -134,6 +132,44 @@ public class TossPaymentsClient {
             return "알 수 없는 오류";
         } catch (Exception e) {
             return "에러 메시지 파싱 실패";
+        }
+    }
+
+    public TossPaymentResponse cancelPayment(String paymentKey, Integer cancelAmount, String cancelReason) {
+        String url = baseUrl + "/v1/payments/" + paymentKey + "/cancel";
+
+        // 요청 헤더 설정
+        HttpHeaders headers = createHeaders();
+
+        // 요청 바디 설정
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("cancelAmount", cancelAmount);
+        requestBody.put("cancelReason", cancelReason);
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(requestBody, headers);
+
+        try {
+            log.info("TossPayments 전체 취소 요청 - paymentKey: {}, amount: {}, reason: {}", paymentKey, cancelAmount, cancelReason);
+
+            ResponseEntity<TossPaymentResponse> response = restTemplate.postForEntity(url, request, TossPaymentResponse.class);
+            if (response.getStatusCode() == HttpStatus.OK && response.getBody() != null) {
+                TossPaymentResponse result = response.getBody();
+                log.info("TossPayments 취소 완료 - paymentKey: {}, status: {}", paymentKey, result.status());
+                return result;
+            } else {
+                log.error("TossPayments 취소 응답 오류: statusCode={}", response.getStatusCode());
+                throw new TossPaymentsException("결제 취소 응답이 올바르지 않습니다.");
+            }
+        } catch (HttpClientErrorException e) {
+            log.error("TossPayments 클라이언트 오류: statusCode={}, responseBody={}", e.getStatusCode(), e.getResponseBodyAsString());
+            String errorMessage = parseErrorMessage(e.getResponseBodyAsString());
+            throw new TossPaymentsException("결제 취소 중 클라이언트 오류가 발생했습니다: " + errorMessage);
+        } catch (HttpServerErrorException e) {
+            log.error("TossPayments 서버 오류: statusCode={}, responseBody={}",  e.getStatusCode(), e.getResponseBodyAsString());
+            throw new TossPaymentsException("결제 취소 중 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        } catch (Exception e) {
+            log.error("TossPayments API 호출 중 예상치 못한 오류 발생", e);
+            throw new TossPaymentsException("결제 취소 중 시스템 오류가 발생했습니다.");
         }
     }
 

--- a/src/main/resources/mapper/member/member_mapper.xml
+++ b/src/main/resources/mapper/member/member_mapper.xml
@@ -167,4 +167,12 @@
         AND point >= #{points}
     </update>
 
+    <!-- 포인트 복구 -->
+    <update id="restorePointsByMemberId">
+        UPDATE member
+        SET points = points + #{points},
+        updated_at = SYSDATE
+        WHERE id = #{memberId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/order/order_history_mapper.xml
+++ b/src/main/resources/mapper/order/order_history_mapper.xml
@@ -92,4 +92,20 @@
         WHERE order_history_id = #{orderHistoryId}
     </update>
 
+    <!-- 기부금 금액 업데이트 -->
+    <update id="updateDonationPrice" parameterType="map">
+        UPDATE order_history
+        SET donation_price = #{donationPrice},
+        updated_at = SYSDATE
+        WHERE order_history_id = #{orderHistoryId}
+    </update>
+
+    <!-- 주문 상태 업데이트 -->
+    <update id="updateOrderStatus" parameterType="map">
+        UPDATE order_history
+        SET order_status = #{orderStatus, typeHandler=org.apache.ibatis.type.EnumTypeHandler},
+        updated_at = #{updatedAt}
+        WHERE order_history_id = #{orderHistoryId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/order/order_product_mapper.xml
+++ b/src/main/resources/mapper/order/order_product_mapper.xml
@@ -32,4 +32,28 @@
         )
     </insert>
 
+    <select id="findOrderProductsByOrderHistoryId" parameterType="long" resultType="org.phoenix.planet.dto.order.raw.OrderProduct">
+        SELECT
+        order_product_id,
+        price,
+        quantity,
+        cancel_status,
+        order_type,
+        order_history_id,
+        product_id,
+        created_at,
+        updated_at
+        FROM order_product
+        WHERE order_history_id = #{orderHistoryId}
+        ORDER BY order_product_id
+    </select>
+
+    <!-- 주문 내 모든 상품 취소 상태 업데이트 -->
+    <update id="updateAllOrderProductsCancelStatus" parameterType="map">
+        UPDATE order_product
+        SET cancel_status = #{cancelStatus, typeHandler=org.apache.ibatis.type.EnumTypeHandler, jdbcType=VARCHAR},
+        updated_at = SYSDATE
+        WHERE order_history_id = #{orderHistoryId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/payment/payment_history_mapper.xml
+++ b/src/main/resources/mapper/payment/payment_history_mapper.xml
@@ -88,4 +88,11 @@
         WHERE order_history_id = #{orderHistoryId}
     </select>
 
+    <update id="updatePaymentStatus" parameterType="map">
+        UPDATE payment_history
+        SET status = #{paymentStatus, typeHandler=org.apache.ibatis.type.EnumTypeHandler},
+        updated_at = SYSDATE
+        WHERE payment_id = #{paymentId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/payment/payment_history_mapper.xml
+++ b/src/main/resources/mapper/payment/payment_history_mapper.xml
@@ -15,8 +15,8 @@
         payment_key,
         order_id,
         total_amount,
-        method,
-        status,
+        payment_method,
+        payment_status,
         requested_at,
         approved_at,
         balance_amount,
@@ -52,8 +52,8 @@
         payment_key as paymentKey,
         order_id as orderId,
         total_amount as totalAmount,
-        method,
-        status,
+        payment_method,
+        payment_status,
         requested_at as requestedAt,
         approved_at as approvedAt,
         balance_amount as balanceAmount,
@@ -74,8 +74,8 @@
         payment_key as paymentKey,
         order_id as orderId,
         total_amount as totalAmount,
-        method,
-        status,
+        payment_method,
+        payment_status,
         requested_at as requestedAt,
         approved_at as approvedAt,
         balance_amount as balanceAmount,
@@ -90,7 +90,7 @@
 
     <update id="updatePaymentStatus" parameterType="map">
         UPDATE payment_history
-        SET status = #{paymentStatus, typeHandler=org.apache.ibatis.type.EnumTypeHandler},
+        SET payment_status = #{paymentStatus, typeHandler=org.apache.ibatis.type.EnumTypeHandler},
         updated_at = SYSDATE
         WHERE payment_id = #{paymentId}
     </update>

--- a/src/main/resources/mapper/shopping/product_mapper.xml
+++ b/src/main/resources/mapper/shopping/product_mapper.xml
@@ -20,15 +20,6 @@
       javaType="java.time.LocalDateTime"/>
   </resultMap>
 
-    <!-- 재고 차감 -->
-    <update id="deductStock">
-        UPDATE product
-        SET quantity = quantity - #{quantity},
-        updated_at = CURRENT_TIMESTAMP
-        WHERE product_id = #{productId}
-        AND quantity >= #{quantity}
-    </update>
-
   <!-- Insert -->
   <insert id="insert" parameterType="org.phoenix.planet.dto.product.raw.Product">
     <selectKey keyProperty="id" resultType="long" order="BEFORE">
@@ -113,6 +104,7 @@
     FROM PRODUCT
     ORDER BY product_id DESC
   </select>
+
   <select id="findTodayAllEcoProducts"
     resultType="org.phoenix.planet.dto.product.response.EcoProductListResponse">
     SELECT
@@ -131,7 +123,6 @@
     AND TRUNC(p.created_at) = TRUNC(SYSDATE)
     ORDER BY p.created_at DESC
   </select>
-
 
   <select id="findByIdIn" resultType="org.phoenix.planet.dto.product.response.ProductResponse">
     SELECT
@@ -219,5 +210,22 @@
     where P.PRODUCT_ID = #{productId}
     order by PRODUCT_IMAGE_ID
   </select>
+
+  <!-- 재고 차감 -->
+  <update id="deductStock">
+    UPDATE product
+    SET quantity = quantity - #{quantity},
+    updated_at = CURRENT_TIMESTAMP
+    WHERE product_id = #{productId}
+    AND quantity >= #{quantity}
+  </update>
+
+  <!-- 재고 복구 -->
+  <update id="restoreStock" parameterType="map">
+    UPDATE product
+    SET quantity = quantity + #{quantity},
+    updated_at = SYSDATE
+    WHERE product_id = #{productId}
+  </update>
 
 </mapper>


### PR DESCRIPTION
# 🚀 결제 전체 취소 API 구현
## 📌 개요
TossPayments 취소 연동을 통한 결제 전체 취소 기능을 구현했습니다. 결제 완료(PAID) 상태에서만 취소 가능합니다(구매 확정 후에는 취소 불가).

---

## 📋 작업 내용

### 주요 기능
- 결제 전체 취소: TossPayments API 연동을 통한 결제 취소
- 재고 복구: 취소된 상품의 재고 자동 복구
- 포인트 환불: 사용한 포인트 즉시 환불
- 기부금 취소: 전체 취소 시, 기부금 전액 환불
- 주문 상태 관리: ALL_CANCELLED 상태로 업데이트