### PR TITLE
feat: elastic search gcp에서 온프레미스 도커 컨테이너로 마이그레이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
+    // Elastic Search
+    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+
     // FCM
     implementation 'com.google.firebase:firebase-admin:9.2.0'
 

--- a/src/main/java/org/phoenix/planet/dto/product/raw/ProductDoc.java
+++ b/src/main/java/org/phoenix/planet/dto/product/raw/ProductDoc.java
@@ -1,0 +1,12 @@
+package org.phoenix.planet.dto.product.raw;
+
+public record ProductDoc(
+    String productId,
+    String productName,
+    String brandName,
+    String categoryName,
+    String categoryId,
+    String imageUrl
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/service/elasticsearch/EsService.java
+++ b/src/main/java/org/phoenix/planet/service/elasticsearch/EsService.java
@@ -1,0 +1,161 @@
+package org.phoenix.planet.service.elasticsearch;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.product.raw.ProductDoc;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EsService {
+
+    private final ElasticsearchClient esClient;
+
+    private final String index = "planet_product_new";
+    private final int defaultSize = 10;
+
+    public List<String> searchMltMatchAll(String likeText, String categoryId, Integer size) {
+
+        int k = (size == null || size <= 0) ? defaultSize : size;
+
+        // 카테고리 필터 (있으면 term 추가)
+        Query categoryFilter = (categoryId != null && !categoryId.isBlank())
+            ? Query.of(q -> q.term(t -> t.field("categoryId").value(categoryId)))
+            : null;
+
+        // should 절
+        List<Query> shouldQueries = List.of(
+            Query.of(q -> q.term(t -> t.field("productName.keyword").value(likeText).boost(8.0f))),
+            Query.of(q -> q.matchPhrase(m -> m.field("productName").query(likeText).boost(5.0f))),
+            Query.of(q -> q.match(m -> m.field("productName").query(likeText)
+                .operator(Operator.And)
+                .minimumShouldMatch("100%")
+                .boost(3.0f))),
+            Query.of(q -> q.multiMatch(mm -> mm.query(likeText)
+                .fields("productName^2", "brandName")
+                .fuzziness("AUTO")
+                .boost(1.0f))),
+            Query.of(q -> q.matchPhrasePrefix(mpp -> mpp.field("productName")
+                .query(likeText)
+                .maxExpansions(50)
+                .boost(1.0f)))
+        );
+
+        // 최종 query
+        Query boolQuery = Query.of(q -> q.bool(b -> {
+            if (categoryFilter != null) {
+                b.filter(categoryFilter);
+            }
+            b.must(m -> m.matchAll(ma -> ma));
+            b.should(shouldQueries);
+            return b;
+        }));
+
+        // SearchRequest 생성
+        SearchRequest request = SearchRequest.of(s -> s
+            .index(index)
+            .size(k)
+            .query(boolQuery)
+            .sort(SortOptions.of(so -> so.score(sc -> sc)))
+            .source(src -> src.filter(f -> f.includes(
+                "productId", "productName", "brandName",
+                "categoryName", "categoryId", "imageUrl"
+            )))
+        );
+
+        // 실행
+        try {
+            SearchResponse<ProductDoc> response = esClient.search(request, ProductDoc.class);
+            return response.hits().hits().stream()
+                .map(h -> h.source().productId())
+                .collect(Collectors.toList());
+        } catch (IOException e) {
+            log.warn("[searchMltMatchAll]: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 유사 상품 추천 (more_like_this + filter + must_not)
+     */
+    public List<String> searchSimilarIds(
+        String anchorName,
+        String anchorCategoryId,
+        String anchorId,
+        Integer size
+    ) {
+
+        int k = (size == null || size <= 0) ? defaultSize : size;
+
+        // filter: categoryId
+        Query categoryFilter = (anchorCategoryId != null && !anchorCategoryId.isBlank())
+            ? Query.of(q -> q.term(t -> t.field("categoryId").value(anchorCategoryId)))
+            : null;
+
+        // must_not: productId
+        Query mustNot = (anchorId != null && !anchorId.isBlank())
+            ? Query.of(q -> q.term(t -> t.field("productId").value(anchorId)))
+            : null;
+
+        // 요청 빌드 (rescore with more_like_this)
+        SearchRequest request = SearchRequest.of(s -> {
+            s.index(index)
+                .size(k)
+                .source(src -> src.filter(f -> f.includes(
+                    "productId", "productName", "brandName",
+                    "categoryName", "categoryId", "imageUrl"
+                )))
+                .query(q -> q.bool(b -> {
+                    if (categoryFilter != null) {
+                        b.filter(categoryFilter);
+                    }
+                    if (mustNot != null) {
+                        b.mustNot(mustNot);
+                    }
+                    return b;
+                }))
+                .rescore(r -> r
+                    .windowSize(200)
+                    .query(rq -> rq
+                        .query(Query.of(q -> q.moreLikeThis(mlt -> {
+                            mlt.fields("productName")
+                                .minTermFreq(1)
+                                .minDocFreq(1)
+                                .maxQueryTerms(50);
+
+                            if (anchorId != null && !anchorId.isBlank()) {
+                                mlt.like(l -> l.document(d -> d.index(index).id(anchorId)));
+                            } else if (anchorName != null && !anchorName.isBlank()) {
+                                mlt.like(l -> l.text(anchorName));
+                            }
+                            return mlt;
+                        })))
+                        .queryWeight(0.2)
+                        .rescoreQueryWeight(2.0)
+                    )
+                );
+            return s;
+        });
+
+        try {
+            SearchResponse<ProductDoc> response = esClient.search(request, ProductDoc.class);
+            return response.hits().hits().stream()
+                .map(h -> h.source().productId())
+                .collect(Collectors.toList());
+        } catch (IOException e) {
+            log.warn("[searchSimilarIds]: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/org/phoenix/planet/service/product/ProductServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/product/ProductServiceImpl.java
@@ -15,7 +15,7 @@ import org.phoenix.planet.dto.product.response.EcoProductListResponse;
 import org.phoenix.planet.dto.product.response.ProductDetailResponse;
 import org.phoenix.planet.dto.product.response.ProductResponse;
 import org.phoenix.planet.mapper.ProductMapper;
-import org.phoenix.planet.util.file.EsClient;
+import org.phoenix.planet.service.elasticsearch.EsService;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ProductServiceImpl implements ProductService {
 
-    private final EsClient esClient;
+    private final EsService esService;
     private final ProductMapper productMapper;
 
     @Override
@@ -34,6 +34,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<ProductCategory> getCategories() {
+
         List<ProductCategory> list = productMapper.findAllCategories();
         list.addFirst(ProductCategory.builder().name("전체").build()); // '전체' 카테고리 추가
         return list;
@@ -41,6 +42,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<ProductResponse> findByCategory(Long categoryId) {
+
         return productMapper.findByCategoryId(categoryId);
     }
 
@@ -48,30 +50,31 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public List<ProductResponse> searchByMlt(String keyword, String categoryId, Integer size) {
         // 1) ES 에서 추천 id 받기
-        List<String> ids = esClient.searchMltMatchAll(keyword.trim(), categoryId, size);
+        List<String> ids = esService.searchMltMatchAll(keyword.trim(), categoryId, size);
         if (ids.isEmpty()) {
             return Collections.emptyList();
         }
         // 2) DB 에서 상품 상세 로드
         List<Long> longIds = ids.stream()
-                .map(Long::parseLong)
-                .toList();
+            .map(Long::parseLong)
+            .toList();
         List<ProductResponse> fromDb = productMapper.findByIdIn(longIds);
         // 3) ES 순서대로 상품 목록 정렬
         Map<Long, Integer> esProductOrder = IntStream.range(0, ids.size())
-                .boxed()
-                .collect(Collectors.toMap(
-                        i -> Long.parseLong(ids.get(i)), // productId
-                        i -> i                           // 순서
-                ));
+            .boxed()
+            .collect(Collectors.toMap(
+                i -> Long.parseLong(ids.get(i)), // productId
+                i -> i                           // 순서
+            ));
         fromDb.sort(Comparator.comparingInt(
-                p -> esProductOrder.getOrDefault(p.getProductId(), Integer.MAX_VALUE)));
+            p -> esProductOrder.getOrDefault(p.getProductId(), Integer.MAX_VALUE)));
         return fromDb;
     }
 
     /* 상품 상세 */
     @Override
     public List<ProductDetailResponse> getProductDetail(Long productId) {
+
         return productMapper.getProductDetail(productId);
     }
 
@@ -79,11 +82,11 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public List<ProductResponse> recommend(RecommendRequest req) {
         // 1) ES에서 추천 id만 받기
-        List<String> ids = esClient.searchSimilarIds(
-                req.name(),
-                req.categoryId(),
-                req.productId(),
-                req.size()
+        List<String> ids = esService.searchSimilarIds(
+            req.name(),
+            req.categoryId(),
+            req.productId(),
+            req.size()
         );
         if (ids.isEmpty()) {
             return Collections.emptyList();
@@ -91,8 +94,8 @@ public class ProductServiceImpl implements ProductService {
 
         // 2) Oracle에서 상세 조회
         List<Long> longIds = ids.stream()
-                .map(Long::parseLong)
-                .toList();
+            .map(Long::parseLong)
+            .toList();
         List<ProductResponse> fromDb = productMapper.findByIdIn(longIds);
         if (fromDb.isEmpty()) {
             return fromDb;
@@ -100,12 +103,12 @@ public class ProductServiceImpl implements ProductService {
 
         // 3) ES 순서대로 정렬 (ES ids는 String, DB id는 Long/Integer일 수 있으므로 String 기준으로 맞춤)
         Map<String, Integer> rank = IntStream.range(0, ids.size())
-                .boxed()
-                .collect(Collectors.toMap(
-                        ids::get,
-                        i -> i,
-                        (a, b) -> a // 중복 id가 있을 경우 첫 위치 유지
-                ));
+            .boxed()
+            .collect(Collectors.toMap(
+                ids::get,
+                i -> i,
+                (a, b) -> a // 중복 id가 있을 경우 첫 위치 유지
+            ));
 
         fromDb.sort(Comparator.comparingInt(p -> {
             String key = (p == null) ? "" : String.valueOf(p.getProductId());
@@ -117,6 +120,7 @@ public class ProductServiceImpl implements ProductService {
 
     /* 에코딜 상품 상세 */
     public List<EcoProductDetailResponse> getEcoDealDetail(Long productId) {
+
         return productMapper.getEcoDealDetail(productId);
     }
 }

--- a/src/main/java/org/phoenix/planet/util/file/EsClient.java
+++ b/src/main/java/org/phoenix/planet/util/file/EsClient.java
@@ -1,205 +1,205 @@
-package org.phoenix.planet.util.file;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
-
-@Component
-@RequiredArgsConstructor
-public class EsClient {
-
-    private final RestTemplate restTemplate;
-    private final ObjectMapper objectMapper;
-
-    @Value("${es.endpoint}")
-    private String baseUrl;
-
-    @Value("${es.index}")
-    private String index;
-
-    @Value("${es.inference-id}")
-    private String inferenceId;
-
-    @Value("${es.default-size:20}")
-    private int defaultSize;
-
-    @Value("${es.api-key}")
-    private String apiKey;
-
-    private static final String searchSimilarIdsQuery = """
-            {
-              "_source": ["productId","productName","brandName","categoryName","categoryId","imageUrl"],
-              "size": %d,
-              "query": {
-                "bool": {
-                  "filter": [ { "term": { "categoryId": %s } } ],
-                  "must_not": [ { "term": { "productId": %s } } ]
-                }
-              },
-              "rescore": [
-                {
-                  "window_size": 200,
-                  "query": {
-                    "rescore_query": {
-                      "more_like_this": {
-                        "fields": ["productName"],
-                        "like": [ { "_index": %s, "_id": %s } ],
-                        "min_term_freq": 1,
-                        "min_doc_freq": 1,
-                        "max_query_terms": 50
-                      }
-                    },
-                    "query_weight": 0.2,
-                    "rescore_query_weight": 2.0
-                  }
-                }
-              ]
-            }
-            """;
-
-    private static final String searchMltMatchAllQuery = """
-            {
-              "size": %d,
-              "_source": ["productId","productName","brandName","categoryName","categoryId","imageUrl"],
-              "query": {
-                "bool": {
-                  "filter": [ %s ],
-                  "must": { "match_all": {} },
-                  "should": [
-                    { "term": { "productName.keyword": { "value": %s, "boost": 8 } } },
-                    { "match_phrase": { "productName": { "query": %s, "boost": 5 } } },
-                    { "match": { "productName": { "query": %s, "operator": "AND", "minimum_should_match": "100%%", "boost": 3 } } },
-                    { "multi_match": { "query": %s, "fields": ["productName^2","brandName"], "fuzziness": "AUTO", "boost": 1 } },
-                    { "match_phrase_prefix": { "productName": { "query": %s, "max_expansions": 50, "boost": 1 } } }
-                  ]
-                }
-              },
-              "sort": ["_score"]
-            }
-            """;
-
-    /* 유사 상품 추천 */
-    public List<String> searchSimilarIds(String anchorName, String anchorCategoryId,
-            String anchorId, Integer size) {
-        int k = (size == null || size <= 0) ? defaultSize : size;
-
-        String idx = (this.index == null || this.index.isBlank()) ? "planet_product_csv_3_pn_001"
-                : this.index;
-
-        String query = String.format(searchSimilarIdsQuery,
-                k,
-                safeJson(anchorCategoryId),
-                safeJson(anchorId),
-                safeJson(idx),
-                safeJson(anchorId)
-        );
-
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            headers.set("Authorization", "ApiKey " + apiKey);
-            HttpEntity<String> req = new HttpEntity<>(query, headers);
-            ResponseEntity<String> response = restTemplate.exchange(
-                    baseUrl + "/" + idx + "/_search",
-                    HttpMethod.POST,
-                    req,
-                    String.class
-            );
-            String bodyStr = response.getBody();
-            JsonNode resp =
-                    (bodyStr == null || bodyStr.isBlank()) ? null : objectMapper.readTree(bodyStr);
-            if (resp == null || resp.get("hits") == null) {
-                return Collections.emptyList();
-            }
-            return toIds(resp);
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
-    }
-
-    /* 검색 */
-    public List<String> searchMltMatchAll(String likeText, String categoryId, Integer size) {
-        int k = (size == null || size <= 0) ? 10 : size;
-        String idx = (this.index == null || this.index.isBlank()) ? "planet_product_csv_3_pn_001"
-                : this.index;
-
-        // 카테고리 필터 (카테고리 필터가 있는 경우 추가할 쿼리)
-        String catTerm = "";
-        if (categoryId != null && !categoryId.isBlank()) {
-            catTerm = String.format("{ \"term\": { \"categoryId\": %s } }", safeJson(categoryId));
-        }
-
-        String body = String.format(searchMltMatchAllQuery,
-                k,
-                catTerm,
-                safeJson(likeText),
-                safeJson(likeText),
-                safeJson(likeText),
-                safeJson(likeText),
-                safeJson(likeText)
-        );
-
-        try {
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(MediaType.APPLICATION_JSON);
-            headers.set("Authorization", "ApiKey " + apiKey);
-            HttpEntity<String> req = new HttpEntity<>(body, headers);
-            ResponseEntity<String> response = restTemplate.exchange(
-                    baseUrl + "/" + idx + "/_search",
-                    HttpMethod.POST,
-                    req,
-                    String.class
-            );
-            String bodyStr = response.getBody();
-            JsonNode resp =
-                    (bodyStr == null || bodyStr.isBlank()) ? null : objectMapper.readTree(bodyStr);
-            if (resp == null || resp.get("hits") == null) {
-                return Collections.emptyList();
-            }
-            return toIds(resp);
-        } catch (Exception e) {
-            return Collections.emptyList();
-        }
-    }
-
-    /* es 에 요청 보낼 때 json 으로 키워드 파싱 */
-    private String safeJson(String s) {
-        try {
-            return objectMapper.writeValueAsString(s == null ? "" : s);
-        } catch (Exception e) {
-            return "\"\"";
-        }
-    }
-
-    /* es 에서 받은 반환값을 List<String> 형태로 파싱 */
-    private List<String> toIds(JsonNode resp) {
-        JsonNode hits = resp.path("hits").path("hits");
-        if (!hits.isArray()) {
-            return Collections.emptyList();
-        }
-        List<String> ids = new ArrayList<>();
-        for (JsonNode h : hits) {
-            JsonNode source = h.path("_source");
-            String id = Optional.ofNullable(source.path("productId").asText(null))
-                    .orElse(Optional.ofNullable(source.path("product_id").asText(null))
-                            .orElse(Optional.ofNullable(source.path("id").asText(null))
-                                    .orElse(null)));
-            if (id != null) {
-                ids.add(id);
-            }
-        }
-        return ids;
-    }
-}
+//package org.phoenix.planet.util.file;
+//
+//import com.fasterxml.jackson.databind.JsonNode;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.List;
+//import java.util.Optional;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.http.HttpEntity;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.http.HttpMethod;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.stereotype.Component;
+//import org.springframework.web.client.RestTemplate;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class EsClient {
+//
+//    private final RestTemplate restTemplate;
+//    private final ObjectMapper objectMapper;
+//
+//    @Value("${es.endpoint}")
+//    private String baseUrl;
+//
+//    @Value("${es.index}")
+//    private String index;
+//
+//    @Value("${es.inference-id}")
+//    private String inferenceId;
+//
+//    @Value("${es.default-size:20}")
+//    private int defaultSize;
+//
+//    @Value("${es.api-key}")
+//    private String apiKey;
+//
+//    private static final String searchSimilarIdsQuery = """
+//            {
+//              "_source": ["productId","productName","brandName","categoryName","categoryId","imageUrl"],
+//              "size": %d,
+//              "query": {
+//                "bool": {
+//                  "filter": [ { "term": { "categoryId": %s } } ],
+//                  "must_not": [ { "term": { "productId": %s } } ]
+//                }
+//              },
+//              "rescore": [
+//                {
+//                  "window_size": 200,
+//                  "query": {
+//                    "rescore_query": {
+//                      "more_like_this": {
+//                        "fields": ["productName"],
+//                        "like": [ { "_index": %s, "_id": %s } ],
+//                        "min_term_freq": 1,
+//                        "min_doc_freq": 1,
+//                        "max_query_terms": 50
+//                      }
+//                    },
+//                    "query_weight": 0.2,
+//                    "rescore_query_weight": 2.0
+//                  }
+//                }
+//              ]
+//            }
+//            """;
+//
+//    private static final String searchMltMatchAllQuery = """
+//            {
+//              "size": %d,
+//              "_source": ["productId","productName","brandName","categoryName","categoryId","imageUrl"],
+//              "query": {
+//                "bool": {
+//                  "filter": [ %s ],
+//                  "must": { "match_all": {} },
+//                  "should": [
+//                    { "term": { "productName.keyword": { "value": %s, "boost": 8 } } },
+//                    { "match_phrase": { "productName": { "query": %s, "boost": 5 } } },
+//                    { "match": { "productName": { "query": %s, "operator": "AND", "minimum_should_match": "100%%", "boost": 3 } } },
+//                    { "multi_match": { "query": %s, "fields": ["productName^2","brandName"], "fuzziness": "AUTO", "boost": 1 } },
+//                    { "match_phrase_prefix": { "productName": { "query": %s, "max_expansions": 50, "boost": 1 } } }
+//                  ]
+//                }
+//              },
+//              "sort": ["_score"]
+//            }
+//            """;
+//
+//    /* 유사 상품 추천 */
+//    public List<String> searchSimilarIds(String anchorName, String anchorCategoryId,
+//            String anchorId, Integer size) {
+//        int k = (size == null || size <= 0) ? defaultSize : size;
+//
+//        String idx = (this.index == null || this.index.isBlank()) ? "planet_product_csv_3_pn_001"
+//                : this.index;
+//
+//        String query = String.format(searchSimilarIdsQuery,
+//                k,
+//                safeJson(anchorCategoryId),
+//                safeJson(anchorId),
+//                safeJson(idx),
+//                safeJson(anchorId)
+//        );
+//
+//        try {
+//            HttpHeaders headers = new HttpHeaders();
+//            headers.setContentType(MediaType.APPLICATION_JSON);
+//            headers.set("Authorization", "ApiKey " + apiKey);
+//            HttpEntity<String> req = new HttpEntity<>(query, headers);
+//            ResponseEntity<String> response = restTemplate.exchange(
+//                    baseUrl + "/" + idx + "/_search",
+//                    HttpMethod.POST,
+//                    req,
+//                    String.class
+//            );
+//            String bodyStr = response.getBody();
+//            JsonNode resp =
+//                    (bodyStr == null || bodyStr.isBlank()) ? null : objectMapper.readTree(bodyStr);
+//            if (resp == null || resp.get("hits") == null) {
+//                return Collections.emptyList();
+//            }
+//            return toIds(resp);
+//        } catch (Exception e) {
+//            return Collections.emptyList();
+//        }
+//    }
+//
+//    /* 검색 */
+//    public List<String> searchMltMatchAll(String likeText, String categoryId, Integer size) {
+//        int k = (size == null || size <= 0) ? 10 : size;
+//        String idx = (this.index == null || this.index.isBlank()) ? "planet_product_csv_3_pn_001"
+//                : this.index;
+//
+//        // 카테고리 필터 (카테고리 필터가 있는 경우 추가할 쿼리)
+//        String catTerm = "";
+//        if (categoryId != null && !categoryId.isBlank()) {
+//            catTerm = String.format("{ \"term\": { \"categoryId\": %s } }", safeJson(categoryId));
+//        }
+//
+//        String body = String.format(searchMltMatchAllQuery,
+//                k,
+//                catTerm,
+//                safeJson(likeText),
+//                safeJson(likeText),
+//                safeJson(likeText),
+//                safeJson(likeText),
+//                safeJson(likeText)
+//        );
+//
+//        try {
+//            HttpHeaders headers = new HttpHeaders();
+//            headers.setContentType(MediaType.APPLICATION_JSON);
+//            headers.set("Authorization", "ApiKey " + apiKey);
+//            HttpEntity<String> req = new HttpEntity<>(body, headers);
+//            ResponseEntity<String> response = restTemplate.exchange(
+//                    baseUrl + "/" + idx + "/_search",
+//                    HttpMethod.POST,
+//                    req,
+//                    String.class
+//            );
+//            String bodyStr = response.getBody();
+//            JsonNode resp =
+//                    (bodyStr == null || bodyStr.isBlank()) ? null : objectMapper.readTree(bodyStr);
+//            if (resp == null || resp.get("hits") == null) {
+//                return Collections.emptyList();
+//            }
+//            return toIds(resp);
+//        } catch (Exception e) {
+//            return Collections.emptyList();
+//        }
+//    }
+//
+//    /* es 에 요청 보낼 때 json 으로 키워드 파싱 */
+//    private String safeJson(String s) {
+//        try {
+//            return objectMapper.writeValueAsString(s == null ? "" : s);
+//        } catch (Exception e) {
+//            return "\"\"";
+//        }
+//    }
+//
+//    /* es 에서 받은 반환값을 List<String> 형태로 파싱 */
+//    private List<String> toIds(JsonNode resp) {
+//        JsonNode hits = resp.path("hits").path("hits");
+//        if (!hits.isArray()) {
+//            return Collections.emptyList();
+//        }
+//        List<String> ids = new ArrayList<>();
+//        for (JsonNode h : hits) {
+//            JsonNode source = h.path("_source");
+//            String id = Optional.ofNullable(source.path("productId").asText(null))
+//                    .orElse(Optional.ofNullable(source.path("product_id").asText(null))
+//                            .orElse(Optional.ofNullable(source.path("id").asText(null))
+//                                    .orElse(null)));
+//            if (id != null) {
+//                ids.add(id);
+//            }
+//        }
+//        return ids;
+//    }
+//}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,8 +10,15 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 12MB
+
   jackson:
     time-zone: Asia/Seoul
+
+  elasticsearch:
+    uris: ${ES_ENDPOINT}
+    username: ${ES_USERNAME}
+    password: ${ES_PASSWORD}
+
   kafka:
     bootstrap-servers: ${KAFKA_HOST}:${KAFKA_PORT}
 
@@ -78,11 +85,4 @@ toss:
   payments:
     api-url: https://api.tosspayments.com
     secret-key: ${TOSS_SECRET_KEY}
-
-es:
-  endpoint: ${ES_ENDPOINT}
-  index: "planet_product_csv_3_pn_001"
-  apiKey: ${ES_API_KEY}
-  inferenceId: "my-elser"
-  defaultSize: 20
 


### PR DESCRIPTION
- 도메인: planet-elasticsearch.jaeyoung.store, planet-kibana.jaeyoung.store
- 데이터 마이그레이션
- https username, password 방식으로 변경
- 기존의 rest template 방식을 Java DSL 방식으로 수정