### PR TITLE
feat: 에코스톡 발급 시에 푸시알림, 멤버 스톡 info 데이터 업데이트되도록 구현

### DIFF
--- a/src/main/java/org/phoenix/planet/consumer/OfflinePayDetectedConsumer.java
+++ b/src/main/java/org/phoenix/planet/consumer/OfflinePayDetectedConsumer.java
@@ -2,21 +2,13 @@ package org.phoenix.planet.consumer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.phoenix.planet.constant.KafkaTopic;
-import org.phoenix.planet.dto.eco_stock.raw.EcoStock;
 import org.phoenix.planet.event.PayEvent;
 import org.phoenix.planet.service.card.MemberCardService;
 import org.phoenix.planet.service.eco_stock.EcoStockIssueService;
-import org.phoenix.planet.service.eco_stock.EcoStockService;
-import org.phoenix.planet.service.fcm.FcmService;
-import org.phoenix.planet.service.fcm.MemberDeviceTokenService;
-import org.phoenix.planet.service.offline.OfflinePayHistoryService;
-import org.phoenix.planet.service.offline.OfflineProductService;
-import org.phoenix.planet.service.offline.OfflineShopService;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -29,14 +21,8 @@ public class OfflinePayDetectedConsumer {
 
     private final ObjectMapper objectMapper;
 
-    private final FcmService fcmService;
-    private final EcoStockService ecoStockService;
     private final MemberCardService memberCardService;
-    private final OfflineShopService offlineShopService;
     private final EcoStockIssueService ecoStockIssueService;
-    private final MemberDeviceTokenService memberDeviceTokenService;
-    private final OfflinePayHistoryService offlinePayHistoryService;
-    private final OfflineProductService offlineProductService;
 
     @Transactional
     @KafkaListener(
@@ -56,28 +42,16 @@ public class OfflinePayDetectedConsumer {
 
         if (memberId != null) { // 등록된 카드이면
             Long ecoStockId = null;
-            String fcmMessage = null;
-            String targetUrl = "/my-page/my-eco-stock";
+
             if ("TUMBLER_DISCOUNT".equals(event.eventName())) {
                 ecoStockId = 1L; // 텀블러 에코스톡 id
-                fcmMessage = "텀블러 사용으로 에코스톡 1주가 발급되었습니다.";
             } else if ("PAPER_BAG_NO_USE".equals(event.eventName())) {
                 ecoStockId = 4L; // 종이백 미사용 에코스톡 id
-                fcmMessage = "종이백 미사용으로 에코스톡 1주가 발급되었습니다.";
             }
+
             if (ecoStockId != null) {
                 // 에코스톡 발급
                 ecoStockIssueService.issueStock(memberId, ecoStockId, 1);
-                // FCM 토큰 목록 가져오기
-                List<String> tokens = memberDeviceTokenService.getTokens(
-                    memberId);
-                // 에코스톡 정보 가져와 푸시 알림 보내기
-                EcoStock ecoStock = ecoStockService.searchById(ecoStockId);
-                // TODO: 에코스톡 발급 처리 (어떻게 하지?)
-//                offlinePayHistoryService.updateStockIssueStatusTrue(event.offlinePayHistoryId());
-                // 알람 전송
-                fcmService.SendEcoStockIssueNotification(tokens, fcmMessage);
-                log.info("{} 에코스톡 발급 완료", ecoStock.name());
             }
 
         } else { // 아직 등록되지 않은 카드면 할 수 있는게 없다고 생각...

--- a/src/main/java/org/phoenix/planet/mapper/MemberCarMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberCarMapper.java
@@ -1,5 +1,6 @@
 package org.phoenix.planet.mapper;
 
+import java.util.Optional;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.phoenix.planet.dto.car.response.MemberCarResponse;
@@ -7,10 +8,10 @@ import org.phoenix.planet.dto.car.response.MemberCarResponse;
 @Mapper
 public interface MemberCarMapper {
 
-    MemberCarResponse selectByMemberId(
+    Optional<MemberCarResponse> selectByMemberId(
         @Param("memberId") long memberId);
 
-    MemberCarResponse selectByCarNumber(
+    Optional<MemberCarResponse> selectByCarNumber(
         @Param("carNumber") String carNumber);
 
     void insert(

--- a/src/main/java/org/phoenix/planet/mapper/MemberStockInfoMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberStockInfoMapper.java
@@ -1,15 +1,21 @@
 package org.phoenix.planet.mapper;
 
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
 import org.phoenix.planet.dto.eco_stock_info.response.MemberStockInfoWithDetail;
 
-import java.util.List;
-
 @Mapper
 public interface MemberStockInfoMapper {
-    MemberStockInfo findPersonalStockInfoById(@Param("memberId") Long memberId, @Param("ecoStockId") Long ecoStockId);
+
+    MemberStockInfo findPersonalStockInfoById(@Param("memberId") Long memberId,
+        @Param("ecoStockId") Long ecoStockId);
 
     List<MemberStockInfoWithDetail> findAllPersonalStockInfoByMemberId(Long memberId);
+
+    void updateOrInsert(
+        @Param("memberId") long memberId,
+        @Param("ecoStockId") long ecoStockId,
+        @Param("quantity") int quantity);
 }

--- a/src/main/java/org/phoenix/planet/service/car/MemberMemberCarServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/car/MemberMemberCarServiceImpl.java
@@ -18,13 +18,15 @@ public class MemberMemberCarServiceImpl implements MemberCarService {
     @Override
     public MemberCarResponse searchByMemberId(long memberId) {
 
-        return memberCarMapper.selectByMemberId(memberId);
+        return memberCarMapper.selectByMemberId(memberId)
+            .orElseThrow(() -> new IllegalArgumentException("memberId에 해당하는 차량 정보가 없습니다."));
     }
 
     @Override
     public MemberCarResponse searchByCarNumber(String carNumber) {
 
-        return memberCarMapper.selectByCarNumber(carNumber);
+        return memberCarMapper.selectByCarNumber(carNumber)
+            .orElseThrow(() -> new IllegalArgumentException("carNumber에 해당하는 차량 정보가 없습니다."));
     }
 
     @Override

--- a/src/main/java/org/phoenix/planet/service/eco_stock/EcoStockIssueServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/eco_stock/EcoStockIssueServiceImpl.java
@@ -1,8 +1,11 @@
 package org.phoenix.planet.service.eco_stock;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.phoenix.planet.mapper.EcoStockIssueMapper;
+import org.phoenix.planet.service.fcm.FcmService;
+import org.phoenix.planet.service.fcm.MemberDeviceTokenService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,15 +14,49 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EcoStockIssueServiceImpl implements EcoStockIssueService {
 
+    private final FcmService fcmService;
     private final EcoStockIssueMapper ecoStockIssueMapper;
+    private final MemberStockInfoService memberStockInfoService;
+    private final MemberDeviceTokenService memberDeviceTokenService;
 
     @Override
     @Transactional
     public void issueStock(long memberId, long ecoStockId, int amount) {
-
-        log.info("에코스톡 발급 완료");
+        // 유효성 검사
+        if (amount <= 0) {
+            throw new IllegalArgumentException("잘못된 amount 입니다.");
+        }
+        // 에코스톡 발급
         for (int i = 0; i < amount; i++) {
             ecoStockIssueMapper.insert(memberId, ecoStockId);
         }
+        // FCM 토큰 목록 가져와 푸시 알람 전송
+        List<String> tokens = memberDeviceTokenService.getTokens(memberId);
+        String fcmMessage = createFcmMessage(ecoStockId, amount);
+        fcmService.SendEcoStockIssueNotification(tokens, fcmMessage);
+        // 유저의 에코스톡 보유 정보 수정
+        memberStockInfoService.updateOrInsert(memberId, ecoStockId, amount);
+        log.info("에코스톡 발급 완료");
+    }
+
+    private String createFcmMessage(long ecoStockId, int amount) {
+
+        String fcmMessage;
+        if (ecoStockId == 1L) {
+            fcmMessage = "텀블러 사용으로 에코스톡 %d주가 발급되었습니다.".formatted(amount);
+        } else if (ecoStockId == 2L) {
+            fcmMessage = "친환경 제품 구매로 에코스톡 %d주가 발급되었습니다.".formatted(amount);
+        } else if (ecoStockId == 3L) {
+            fcmMessage = "친환경 차량 입차가 감지되어 에코스톡 %d주가 발급되었습니다.".formatted(amount);
+        } else if (ecoStockId == 4L) {
+            fcmMessage = "종이백 미사용으로 에코스톡 %d주가 발급되었습니다.".formatted(amount);
+        } else if (ecoStockId == 5L) {
+            fcmMessage = "봉시활동으로 에코스톡 %d주가 발급되었습니다.".formatted(amount);
+        } else if (ecoStockId == 6L) {
+            fcmMessage = "고객님의 소중한 기부로 에코스톡 %d주가 발급되었습니다.".formatted(amount);
+        } else {
+            throw new IllegalArgumentException("잘못된 eco stock id 입니다.");
+        }
+        return fcmMessage;
     }
 }

--- a/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoService.java
+++ b/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoService.java
@@ -1,12 +1,14 @@
 package org.phoenix.planet.service.eco_stock;
 
+import java.util.List;
 import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
 import org.phoenix.planet.dto.eco_stock_info.response.MemberStockInfoWithDetail;
 
-import java.util.List;
-
 public interface MemberStockInfoService {
+
     MemberStockInfo findPersonalStockInfoById(Long loginMemberId, Long ecoStockId);
 
     List<MemberStockInfoWithDetail> findAllPersonalStockInfoByMemberId(Long loginMemberId);
+
+    void updateOrInsert(long memberId, long ecoStockId, int quantity);
 }

--- a/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/eco_stock/MemberStockInfoServiceImpl.java
@@ -1,13 +1,12 @@
 package org.phoenix.planet.service.eco_stock;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo;
 import org.phoenix.planet.dto.eco_stock_info.response.MemberStockInfoWithDetail;
 import org.phoenix.planet.mapper.MemberStockInfoMapper;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @Slf4j
@@ -18,11 +17,22 @@ public class MemberStockInfoServiceImpl implements MemberStockInfoService {
 
     @Override
     public MemberStockInfo findPersonalStockInfoById(Long memberId, Long ecoStockId) {
+
         return memberStockInfoMapper.findPersonalStockInfoById(memberId, ecoStockId);
     }
 
     @Override
     public List<MemberStockInfoWithDetail> findAllPersonalStockInfoByMemberId(Long memberId) {
+
         return memberStockInfoMapper.findAllPersonalStockInfoByMemberId(memberId);
+    }
+
+    @Override
+    public void updateOrInsert(long memberId, long ecoStockId, int quantity) {
+        // 1. stock_price_history 테이블에서 eco_stock_id로 최신(가장 최근 stock_time)의 가격(stock_price) 가져오기
+        // 2. member_stock_info 테이블의
+        //  current_total_quantity 갯수에 quantity(인자) 더하기 (업데이트)
+        //  current_total_amount(내가 보유한 에코스톡의 구매 당시 가격 합)에 quantity * cur_price 더하기 (업데이트)
+        memberStockInfoMapper.updateOrInsert(memberId, ecoStockId, quantity);
     }
 }

--- a/src/main/resources/mapper/eco_stock/member_stock_info.xml
+++ b/src/main/resources/mapper/eco_stock/member_stock_info.xml
@@ -1,12 +1,54 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.phoenix.planet.mapper.MemberStockInfoMapper">
-
+    <update id="updateOrInsert">
+        MERGE INTO member_stock_info m
+        USING (
+        SELECT
+        #{memberId} AS member_id,
+        #{ecoStockId} AS eco_stock_id,
+        #{quantity} AS add_quantity,
+        (
+        SELECT stock_price
+        FROM stock_price_history
+        WHERE eco_stock_id = #{ecoStockId}
+        ORDER BY stock_time DESC
+        FETCH FIRST 1 ROWS ONLY
+        ) AS cur_price
+        FROM dual
+        ) s
+        ON (m.member_id = s.member_id AND m.eco_stock_id = s.eco_stock_id)
+        WHEN MATCHED THEN
+        UPDATE SET
+        m.current_total_quantity = NVL(m.current_total_quantity,0) + s.add_quantity,
+        m.current_total_amount = NVL(m.current_total_amount,0) + (s.add_quantity * s.cur_price),
+        m.updated_at = SYSDATE
+        WHEN NOT MATCHED THEN
+        INSERT (
+        member_stock_info_id,
+        member_id,
+        eco_stock_id,
+        current_total_quantity,
+        current_total_amount,
+        created_at,
+        updated_at
+        )
+        VALUES (
+        seq_member_stock_info.NEXTVAL,
+        s.member_id,
+        s.eco_stock_id,
+        s.add_quantity,
+        (s.add_quantity * s.cur_price),
+        SYSDATE,
+        SYSDATE
+        )
+    </update>
+    
     <select id="findPersonalStockInfoById"
-            resultType="org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo">
+        resultType="org.phoenix.planet.dto.eco_stock.raw.MemberStockInfo">
         SELECT
         msi.MEMBER_STOCK_INFO_ID as memberStockInfoId,
         m.MEMBER_ID as memberId,
@@ -20,22 +62,22 @@
         AND msi.ECO_STOCK_ID = #{ecoStockId}
         WHERE m.MEMBER_ID = #{memberId}
     </select>
-
+    
     <select id="findAllPersonalStockInfoByMemberId"
-            resultType="org.phoenix.planet.dto.eco_stock_info.response.MemberStockInfoWithDetail">
+        resultType="org.phoenix.planet.dto.eco_stock_info.response.MemberStockInfoWithDetail">
         SELECT
-            msi.MEMBER_STOCK_INFO_ID as memberStockInfoId,
-            msi.MEMBER_ID as memberId,
-            msi.ECO_STOCK_ID as ecoStockId,
-            msi.CURRENT_TOTAL_QUANTITY as currentTotalQuantity,
-            msi.CURRENT_TOTAL_AMOUNT as currentTotalAmount,
-            m.POINT as point,
-            es.NAME as ecoStockName
+        msi.MEMBER_STOCK_INFO_ID as memberStockInfoId,
+        msi.MEMBER_ID as memberId,
+        msi.ECO_STOCK_ID as ecoStockId,
+        msi.CURRENT_TOTAL_QUANTITY as currentTotalQuantity,
+        msi.CURRENT_TOTAL_AMOUNT as currentTotalAmount,
+        m.POINT as point,
+        es.NAME as ecoStockName
         FROM MEMBER m
         JOIN MEMBER_STOCK_INFO msi
-          ON m.MEMBER_ID = msi.MEMBER_ID
+        ON m.MEMBER_ID = msi.MEMBER_ID
         JOIN ECO_STOCK es
-          ON msi.ECO_STOCK_ID = es.ECO_STOCK_ID
+        ON msi.ECO_STOCK_ID = es.ECO_STOCK_ID
         WHERE m.MEMBER_ID = #{memberId}
     </select>
 </mapper>


### PR DESCRIPTION
## 📌 PR 제목
feat: 에코스톡 발급 시 푸시알림 및 멤버 스톡 정보 업데이트 기능 구현

---

## 📖 개요
- 에코스톡 발급 시 사용자에게 푸시 알림을 전송하고,  
  동시에 `member_stock_info` 테이블의 보유 수량/금액을 업데이트하도록 기능을 확장했습니다.  

---

## 🔑 주요 변경 사항
1. **EcoStockIssueServiceImpl**
   - 발급 시 `EcoStockIssueMapper.insert()` 수행 후  
     `memberStockInfoService.updateOrInsert()` 호출하도록 변경
   - FCM 메시지를 `ecoStockId`별로 분기 처리 (텀블러, 차량, 종이백 등)

2. **MemberStockInfoService / Mapper**
   - `updateOrInsert(memberId, ecoStockId, quantity)` 메서드 추가
   - 최신 `stock_price_history` 기준 가격을 가져와 수량/금액 갱신

3. **member_stock_info.xml**
   - Oracle `MERGE` 문을 사용하여 upsert 로직 구현
   - 존재하면 `current_total_quantity`, `current_total_amount` 업데이트
   - 존재하지 않으면 신규 row insert

4. **Consumer**
   - `EcoCarEnterDetectedConsumer`, `OfflinePayDetectedConsumer` 수정
   - 이벤트 수신 시 `ecoStockIssueService.issueStock()` 호출로 발급 → 알림 → 보유 정보 갱신까지 일괄 처리

5. **Mapper 개선**
   - `MemberCarMapper` 메서드 반환 타입을 `Optional<>`로 변경 → 없는 데이터에 대한 예외 처리를 서비스 레벨에서 명확히 처리
   - `MemberStockInfoMapper` 인터페이스 정리

---

## ✅ 기대 효과
- 에코스톡 발급 이벤트 발생 시 **데이터 정합성 보장** (발급/보유 수량 동기화)  
- 사용자 **리얼타임 알림 경험 향상** (FCM 푸시 발송)  
- 향후 다양한 이벤트(`TUMBLER_DISCOUNT`, `PAPER_BAG_NO_USE`, `친환경 차량 입차` 등)에 쉽게 확장 가능  

---

## 🔍 테스트
- [x] 텀블러 할인 이벤트 → 에코스톡 발급 및 FCM 푸시 정상 동작  
- [x] 종이백 미사용 이벤트 → 발급 및 member_stock_info 업데이트 확인  
- [x] 친환경 차량 입차 이벤트 → 보유 수량 증가 및 알림 정상 수신  
- [x] DB: `member_stock_info.current_total_quantity`, `current_total_amount` 갱신 확인  
