### PR TITLE
fix: 사용자 정보 가져올 때, 포인트 추가

### DIFF
--- a/src/main/java/org/phoenix/planet/dto/member/response/MemberProfileResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/member/response/MemberProfileResponse.java
@@ -11,7 +11,8 @@ public record MemberProfileResponse(
         String birth,
         String profileUrl,
         String address,
-        String detailAddress
+        String detailAddress,
+        Long point
 ) {
 
 }

--- a/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
@@ -45,6 +45,7 @@ public class MemberServiceImpl implements MemberService {
                         ? cloudFrontFileUtil.generateSignedUrl(member.getProfileUrl(), 60) : null)
                 .address(member.getAddress())
                 .detailAddress(member.getDetailAddress())
+                .point(member.getPoint())
                 .build();
     }
 


### PR DESCRIPTION
# 🚀 UI 실시간 동기화 수정
---
## 📋 작업 내용
### 사용자 정보 조회 데이터에 포인트 추가
- 주문서에서 사용하는 보유 포인트 조회 용도로 추가했습니다