### PR TITLE
feat: SCRUM-159 관리자 통계 대시보드 API 개발

### DIFF
--- a/src/main/java/org/phoenix/planet/controller/AdminController.java
+++ b/src/main/java/org/phoenix/planet/controller/AdminController.java
@@ -1,0 +1,45 @@
+package org.phoenix.planet.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
+import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
+import org.phoenix.planet.service.admin.AdminService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    /**
+     * 에코스톡 발급 비율 데이터 + 총 발급량 + 에코스톡 종류 수 +
+     *
+     * @return
+     */
+    @GetMapping("/eco-stock-issue-percentage")
+    public ResponseEntity<EcoStockIssuePercentageResponse> fetchEcoStockIssuePercentageData() {
+
+        EcoStockIssuePercentageResponse response = adminService.fetchEcoStockIssuePercentageData();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 사용자별 에코스톡 보유 현황 데이터 + 총 사용자 + 평균 보유량
+     *
+     * @return
+     */
+    @GetMapping("/eco-stock-issue-holdings")
+    public ResponseEntity<EcoStockHoldingAmountGroupByMemberResponse> fetchEcoStockHoldingAmountDataGroupByMember() {
+
+        EcoStockHoldingAmountGroupByMemberResponse response = adminService.fetchEcoStockHoldingAmountDataGroupByMember();
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/org/phoenix/planet/controller/AdminController.java
+++ b/src/main/java/org/phoenix/planet/controller/AdminController.java
@@ -6,6 +6,8 @@ import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMember
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByDayResponse;
+import org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiResponse;
+import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiResponse;
 import org.phoenix.planet.service.admin.AdminService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -67,5 +69,30 @@ public class AdminController {
         ProductOrderDataGroupByCategoryResponse response = adminService.fetchProductOrderDataGroupByCategory();
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * PHTI 유형별 사용자 분포 데이터 + 설문참여한 총 사용자 + 최다 사용자 PHTI
+     *
+     * @return
+     */
+    @GetMapping("/member-percentage-by-phti")
+    public ResponseEntity<MemberPercentageByPhtiResponse> fetchMemberPercentageByPhti() {
+
+        MemberPercentageByPhtiResponse response = adminService.fetchMemberPercentageByPhti();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * PHTI 유형별 주문/교환 패턴 데이터 + 평균 주문 건수
+     *
+     * @return
+     */
+    @GetMapping("/issue-and-order-patterns-by-phti")
+    public ResponseEntity<IssueAndOrderPatternsByPhtiResponse> fetchIssueAndOrderPatternsByPhti() {
+
+        IssueAndOrderPatternsByPhtiResponse response = adminService.fetchIssueAndOrderPatternsByPhti();
+        return ResponseEntity.ok(response);
+    }
+
 
 }

--- a/src/main/java/org/phoenix/planet/controller/AdminController.java
+++ b/src/main/java/org/phoenix/planet/controller/AdminController.java
@@ -2,6 +2,8 @@ package org.phoenix.planet.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.admin.donation.DonationAmountsByDayResponse;
+import org.phoenix.planet.dto.admin.donation.DonatorPercentageResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
@@ -94,5 +96,28 @@ public class AdminController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 날짜별 총 기부 금액 추이 데이터 + 총 기부 금액
+     *
+     * @return
+     */
+    @GetMapping("/donation-amounts-by-day")
+    public ResponseEntity<DonationAmountsByDayResponse> fetchDonationAmountsByDay() {
+
+        DonationAmountsByDayResponse response = adminService.fetchDonationAmountsByDay();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 사용자별 기부 금액 참여율 + 참여 사용자 수 + 참여율
+     *
+     * @return
+     */
+    @GetMapping("/donator-percentage")
+    public ResponseEntity<DonatorPercentageResponse> fetchDonatorPercentage() {
+
+        DonatorPercentageResponse response = adminService.fetchDonatorPercentage();
+        return ResponseEntity.ok(response);
+    }
 
 }

--- a/src/main/java/org/phoenix/planet/controller/AdminController.java
+++ b/src/main/java/org/phoenix/planet/controller/AdminController.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
+import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
+import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByDayResponse;
 import org.phoenix.planet.service.admin.AdminService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -39,6 +41,30 @@ public class AdminController {
     public ResponseEntity<EcoStockHoldingAmountGroupByMemberResponse> fetchEcoStockHoldingAmountDataGroupByMember() {
 
         EcoStockHoldingAmountGroupByMemberResponse response = adminService.fetchEcoStockHoldingAmountDataGroupByMember();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 일별 주문건수/매출 데이터 + 총 주문 건수 + 총 매출액 + 평균 주문 금액
+     *
+     * @return
+     */
+    @GetMapping("/product-orders-group-by-day")
+    public ResponseEntity<ProductOrderDataGroupByDayResponse> fetchProductOrderDataGroupByDay() {
+
+        ProductOrderDataGroupByDayResponse response = adminService.fetchProductOrderDataGroupByDay();
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 카테고리별 판매 비율 데이터 + Top 카테고리
+     *
+     * @return
+     */
+    @GetMapping("/product-orders-group-by-category")
+    public ResponseEntity<ProductOrderDataGroupByCategoryResponse> fetchProductOrderDataGroupByCategory() {
+
+        ProductOrderDataGroupByCategoryResponse response = adminService.fetchProductOrderDataGroupByCategory();
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/org/phoenix/planet/dto/admin/donation/DonationAmountsByDayItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/donation/DonationAmountsByDayItem.java
@@ -1,0 +1,8 @@
+package org.phoenix.planet.dto.admin.donation;
+
+public record DonationAmountsByDayItem(
+    String date,
+    long donation
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/donation/DonationAmountsByDayResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/donation/DonationAmountsByDayResponse.java
@@ -1,0 +1,12 @@
+package org.phoenix.planet.dto.admin.donation;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record DonationAmountsByDayResponse(
+    long totalDonation,
+    List<DonationAmountsByDayItem> items
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/donation/DonatorPercentageItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/donation/DonatorPercentageItem.java
@@ -1,0 +1,9 @@
+package org.phoenix.planet.dto.admin.donation;
+
+public record DonatorPercentageItem(
+    String name,  // 참여 / 미참여
+    long users,
+    String color
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/donation/DonatorPercentageResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/donation/DonatorPercentageResponse.java
@@ -1,0 +1,13 @@
+package org.phoenix.planet.dto.admin.donation;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record DonatorPercentageResponse(
+    long totalUsers,
+    long participationRate,
+    List<DonatorPercentageItem> items
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/eco_stock/EcoStockHoldingAmountGroupByMemberResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/eco_stock/EcoStockHoldingAmountGroupByMemberResponse.java
@@ -1,0 +1,14 @@
+package org.phoenix.planet.dto.admin.eco_stock;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record EcoStockHoldingAmountGroupByMemberResponse(
+    long totalUsers,              // 총 사용자 수
+    long totalIssued,             // 총 발급량
+    double avgHolding,            // 평균 보유량
+    List<HoldingItem> items       // 구간별 분포
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/eco_stock/EcoStockIssuePercentageResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/eco_stock/EcoStockIssuePercentageResponse.java
@@ -1,0 +1,13 @@
+package org.phoenix.planet.dto.admin.eco_stock;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record EcoStockIssuePercentageResponse(
+    long totalIssued,             // 총 발급량
+    int ecoStockTypes,            // 에코스톡 종류 수
+    List<IssueItem> items         // 각 에코스톡별 비율 데이터
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/eco_stock/HoldingItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/eco_stock/HoldingItem.java
@@ -1,0 +1,9 @@
+package org.phoenix.planet.dto.admin.eco_stock;
+
+public record HoldingItem(
+    String range,             // "1-10개" 같은 구간
+    long userCount,
+    double percentage
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/eco_stock/IssueItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/eco_stock/IssueItem.java
@@ -1,0 +1,10 @@
+package org.phoenix.planet.dto.admin.eco_stock;
+
+public record IssueItem(
+    String name,
+    int count,
+    double value,   // 비율 (%)
+    String color
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/order_product/CategoryItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/order_product/CategoryItem.java
@@ -1,0 +1,9 @@
+package org.phoenix.planet.dto.admin.order_product;
+
+public record CategoryItem(
+    String category,
+    long value,
+    String color
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/order_product/DayItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/order_product/DayItem.java
@@ -1,0 +1,9 @@
+package org.phoenix.planet.dto.admin.order_product;
+
+public record DayItem(
+    String date,
+    long orders,
+    long revenue
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/order_product/ProductOrderDataGroupByCategoryResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/order_product/ProductOrderDataGroupByCategoryResponse.java
@@ -1,0 +1,12 @@
+package org.phoenix.planet.dto.admin.order_product;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ProductOrderDataGroupByCategoryResponse(
+    String topCategory,
+    List<CategoryItem> items
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/order_product/ProductOrderDataGroupByDayResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/order_product/ProductOrderDataGroupByDayResponse.java
@@ -1,0 +1,14 @@
+package org.phoenix.planet.dto.admin.order_product;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ProductOrderDataGroupByDayResponse(
+    long totalOrders,
+    long totalRevenue,
+    long avgOrderValue,
+    List<DayItem> items
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/phti/IssueAndOrderPatternsByPhtiItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/phti/IssueAndOrderPatternsByPhtiItem.java
@@ -1,0 +1,9 @@
+package org.phoenix.planet.dto.admin.phti;
+
+public record IssueAndOrderPatternsByPhtiItem(
+    String type,
+    long orders,
+    long exchanges
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/phti/IssueAndOrderPatternsByPhtiResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/phti/IssueAndOrderPatternsByPhtiResponse.java
@@ -1,0 +1,12 @@
+package org.phoenix.planet.dto.admin.phti;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record IssueAndOrderPatternsByPhtiResponse(
+    long avgOrders,
+    List<IssueAndOrderPatternsByPhtiItem> items
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/phti/MemberPercentageByPhtiItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/phti/MemberPercentageByPhtiItem.java
@@ -1,0 +1,8 @@
+package org.phoenix.planet.dto.admin.phti;
+
+public record MemberPercentageByPhtiItem(
+    String type,
+    long users
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/admin/phti/MemberPercentageByPhtiResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/phti/MemberPercentageByPhtiResponse.java
@@ -1,0 +1,13 @@
+package org.phoenix.planet.dto.admin.phti;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record MemberPercentageByPhtiResponse(
+    long totalUsers,
+    String topPhti,
+    List<MemberPercentageByPhtiItem> items
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
@@ -4,6 +4,8 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
 import org.phoenix.planet.dto.admin.eco_stock.IssueItem;
+import org.phoenix.planet.dto.admin.order_product.CategoryItem;
+import org.phoenix.planet.dto.admin.order_product.DayItem;
 
 @Mapper
 public interface AdminMapper {
@@ -11,4 +13,8 @@ public interface AdminMapper {
     List<IssueItem> selectEcoStockIssuePercentageData();
 
     List<HoldingItem> selectEcoStockHoldingAmountDataGroupByMember();
+
+    List<DayItem> selectProductOrderDataGroupByDay();
+
+    List<CategoryItem> selectProductOrderDataGroupByCategory();
 }

--- a/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
@@ -1,0 +1,14 @@
+package org.phoenix.planet.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
+import org.phoenix.planet.dto.admin.eco_stock.IssueItem;
+
+@Mapper
+public interface AdminMapper {
+
+    List<IssueItem> selectEcoStockIssuePercentageData();
+
+    List<HoldingItem> selectEcoStockHoldingAmountDataGroupByMember();
+}

--- a/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
@@ -6,6 +6,8 @@ import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
 import org.phoenix.planet.dto.admin.eco_stock.IssueItem;
 import org.phoenix.planet.dto.admin.order_product.CategoryItem;
 import org.phoenix.planet.dto.admin.order_product.DayItem;
+import org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiItem;
+import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiItem;
 
 @Mapper
 public interface AdminMapper {
@@ -17,4 +19,8 @@ public interface AdminMapper {
     List<DayItem> selectProductOrderDataGroupByDay();
 
     List<CategoryItem> selectProductOrderDataGroupByCategory();
+
+    List<MemberPercentageByPhtiItem> selectMemberPercentageByPhti();
+
+    List<IssueAndOrderPatternsByPhtiItem> selectIssueAndOrderPatternsByPhti();
 }

--- a/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/AdminMapper.java
@@ -2,6 +2,8 @@ package org.phoenix.planet.mapper;
 
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
+import org.phoenix.planet.dto.admin.donation.DonationAmountsByDayItem;
+import org.phoenix.planet.dto.admin.donation.DonatorPercentageItem;
 import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
 import org.phoenix.planet.dto.admin.eco_stock.IssueItem;
 import org.phoenix.planet.dto.admin.order_product.CategoryItem;
@@ -23,4 +25,8 @@ public interface AdminMapper {
     List<MemberPercentageByPhtiItem> selectMemberPercentageByPhti();
 
     List<IssueAndOrderPatternsByPhtiItem> selectIssueAndOrderPatternsByPhti();
+
+    List<DonationAmountsByDayItem> selectDonationAmountsByDay();
+
+    List<DonatorPercentageItem> selectDonatorPercentage();
 }

--- a/src/main/java/org/phoenix/planet/service/admin/AdminService.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminService.java
@@ -2,10 +2,16 @@ package org.phoenix.planet.service.admin;
 
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
+import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
+import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByDayResponse;
 
 public interface AdminService {
 
     EcoStockIssuePercentageResponse fetchEcoStockIssuePercentageData();
 
     EcoStockHoldingAmountGroupByMemberResponse fetchEcoStockHoldingAmountDataGroupByMember();
+
+    ProductOrderDataGroupByDayResponse fetchProductOrderDataGroupByDay();
+
+    ProductOrderDataGroupByCategoryResponse fetchProductOrderDataGroupByCategory();
 }

--- a/src/main/java/org/phoenix/planet/service/admin/AdminService.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminService.java
@@ -1,5 +1,7 @@
 package org.phoenix.planet.service.admin;
 
+import org.phoenix.planet.dto.admin.donation.DonationAmountsByDayResponse;
+import org.phoenix.planet.dto.admin.donation.DonatorPercentageResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
@@ -20,4 +22,8 @@ public interface AdminService {
     MemberPercentageByPhtiResponse fetchMemberPercentageByPhti();
 
     IssueAndOrderPatternsByPhtiResponse fetchIssueAndOrderPatternsByPhti();
+
+    DonationAmountsByDayResponse fetchDonationAmountsByDay();
+
+    DonatorPercentageResponse fetchDonatorPercentage();
 }

--- a/src/main/java/org/phoenix/planet/service/admin/AdminService.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminService.java
@@ -4,6 +4,8 @@ import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMember
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByDayResponse;
+import org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiResponse;
+import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiResponse;
 
 public interface AdminService {
 
@@ -14,4 +16,8 @@ public interface AdminService {
     ProductOrderDataGroupByDayResponse fetchProductOrderDataGroupByDay();
 
     ProductOrderDataGroupByCategoryResponse fetchProductOrderDataGroupByCategory();
+
+    MemberPercentageByPhtiResponse fetchMemberPercentageByPhti();
+
+    IssueAndOrderPatternsByPhtiResponse fetchIssueAndOrderPatternsByPhti();
 }

--- a/src/main/java/org/phoenix/planet/service/admin/AdminService.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminService.java
@@ -1,0 +1,11 @@
+package org.phoenix.planet.service.admin;
+
+import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
+import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
+
+public interface AdminService {
+
+    EcoStockIssuePercentageResponse fetchEcoStockIssuePercentageData();
+
+    EcoStockHoldingAmountGroupByMemberResponse fetchEcoStockHoldingAmountDataGroupByMember();
+}

--- a/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
@@ -1,0 +1,55 @@
+package org.phoenix.planet.service.admin;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
+import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
+import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
+import org.phoenix.planet.dto.admin.eco_stock.IssueItem;
+import org.phoenix.planet.mapper.AdminMapper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    private final AdminMapper adminMapper;
+
+    @Override
+    public EcoStockIssuePercentageResponse fetchEcoStockIssuePercentageData() {
+
+        List<IssueItem> items = adminMapper.selectEcoStockIssuePercentageData();
+
+        long totalIssued = items.stream()
+            .mapToLong(IssueItem::count)
+            .sum();
+        int ecoStockTypes = items.size();
+
+        return EcoStockIssuePercentageResponse.builder()
+            .totalIssued(totalIssued)
+            .ecoStockTypes(ecoStockTypes)
+            .items(items)
+            .build();
+    }
+
+    @Override
+    public EcoStockHoldingAmountGroupByMemberResponse fetchEcoStockHoldingAmountDataGroupByMember() {
+
+        List<HoldingItem> items = adminMapper.selectEcoStockHoldingAmountDataGroupByMember();
+
+        long totalUsers = items.stream()
+            .mapToLong(HoldingItem::userCount)
+            .sum();
+        long totalIssued = 0;
+        double avgHolding = totalUsers > 0 ? (double) totalIssued / totalUsers : 0;
+
+        return EcoStockHoldingAmountGroupByMemberResponse.builder()
+            .totalUsers(totalUsers)
+            .totalIssued(totalIssued)
+            .avgHolding(avgHolding)
+            .items(items)
+            .build();
+    }
+}

--- a/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
@@ -3,6 +3,10 @@ package org.phoenix.planet.service.admin;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.admin.donation.DonationAmountsByDayItem;
+import org.phoenix.planet.dto.admin.donation.DonationAmountsByDayResponse;
+import org.phoenix.planet.dto.admin.donation.DonatorPercentageItem;
+import org.phoenix.planet.dto.admin.donation.DonatorPercentageResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMemberResponse;
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
 import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
@@ -128,6 +132,45 @@ public class AdminServiceImpl implements AdminService {
 
         return IssueAndOrderPatternsByPhtiResponse.builder()
             .avgOrders(avgOrders)
+            .items(items)
+            .build();
+    }
+
+    @Override
+    public DonationAmountsByDayResponse fetchDonationAmountsByDay() {
+
+        List<DonationAmountsByDayItem> items = adminMapper.selectDonationAmountsByDay();
+
+        long totalDonation = items.stream()
+            .mapToLong(DonationAmountsByDayItem::donation)
+            .sum();
+
+        return DonationAmountsByDayResponse.builder()
+            .totalDonation(totalDonation)
+            .items(items)
+            .build();
+    }
+
+    @Override
+    public DonatorPercentageResponse fetchDonatorPercentage() {
+
+        List<DonatorPercentageItem> items = adminMapper.selectDonatorPercentage();
+
+        long totalUsers = items.stream()
+            .mapToLong(DonatorPercentageItem::users)
+            .sum();
+
+        long participation = items.stream()
+            .filter(i -> i.name().equals("참여"))
+            .mapToLong(DonatorPercentageItem::users)
+            .sum();
+
+        long participationRate =
+            totalUsers > 0 ? Math.round((participation * 100.0) / totalUsers) : 0;
+
+        return DonatorPercentageResponse.builder()
+            .totalUsers(totalUsers)
+            .participationRate(participationRate)
             .items(items)
             .build();
     }

--- a/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
@@ -7,6 +7,10 @@ import org.phoenix.planet.dto.admin.eco_stock.EcoStockHoldingAmountGroupByMember
 import org.phoenix.planet.dto.admin.eco_stock.EcoStockIssuePercentageResponse;
 import org.phoenix.planet.dto.admin.eco_stock.HoldingItem;
 import org.phoenix.planet.dto.admin.eco_stock.IssueItem;
+import org.phoenix.planet.dto.admin.order_product.CategoryItem;
+import org.phoenix.planet.dto.admin.order_product.DayItem;
+import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
+import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByDayResponse;
 import org.phoenix.planet.mapper.AdminMapper;
 import org.springframework.stereotype.Service;
 
@@ -49,6 +53,38 @@ public class AdminServiceImpl implements AdminService {
             .totalUsers(totalUsers)
             .totalIssued(totalIssued)
             .avgHolding(avgHolding)
+            .items(items)
+            .build();
+    }
+
+    public ProductOrderDataGroupByDayResponse fetchProductOrderDataGroupByDay() {
+
+        List<DayItem> items = adminMapper.selectProductOrderDataGroupByDay();
+
+        long totalOrders = items.stream()
+            .mapToLong(DayItem::orders)
+            .sum();
+        long totalRevenue = items.stream()
+            .mapToLong(DayItem::revenue)
+            .sum();
+        long avgOrderValue = totalOrders > 0 ? totalRevenue / totalOrders : 0;
+
+        return ProductOrderDataGroupByDayResponse.builder()
+            .totalOrders(totalOrders)
+            .totalRevenue(totalRevenue)
+            .avgOrderValue(avgOrderValue)
+            .items(items)
+            .build();
+    }
+
+    public ProductOrderDataGroupByCategoryResponse fetchProductOrderDataGroupByCategory() {
+
+        List<CategoryItem> items = adminMapper.selectProductOrderDataGroupByCategory();
+
+        String topCategory = items.isEmpty() ? "" : items.getFirst().category();
+
+        return ProductOrderDataGroupByCategoryResponse.builder()
+            .topCategory(topCategory)
             .items(items)
             .build();
     }

--- a/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
@@ -11,7 +11,12 @@ import org.phoenix.planet.dto.admin.order_product.CategoryItem;
 import org.phoenix.planet.dto.admin.order_product.DayItem;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByCategoryResponse;
 import org.phoenix.planet.dto.admin.order_product.ProductOrderDataGroupByDayResponse;
+import org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiItem;
+import org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiResponse;
+import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiItem;
+import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiResponse;
 import org.phoenix.planet.mapper.AdminMapper;
+import org.phoenix.planet.mapper.MemberPhtiMapper;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -20,6 +25,7 @@ import org.springframework.stereotype.Service;
 public class AdminServiceImpl implements AdminService {
 
     private final AdminMapper adminMapper;
+    private final MemberPhtiMapper memberPhtiMapper;
 
     @Override
     public EcoStockIssuePercentageResponse fetchEcoStockIssuePercentageData() {
@@ -57,6 +63,7 @@ public class AdminServiceImpl implements AdminService {
             .build();
     }
 
+    @Override
     public ProductOrderDataGroupByDayResponse fetchProductOrderDataGroupByDay() {
 
         List<DayItem> items = adminMapper.selectProductOrderDataGroupByDay();
@@ -77,6 +84,7 @@ public class AdminServiceImpl implements AdminService {
             .build();
     }
 
+    @Override
     public ProductOrderDataGroupByCategoryResponse fetchProductOrderDataGroupByCategory() {
 
         List<CategoryItem> items = adminMapper.selectProductOrderDataGroupByCategory();
@@ -85,6 +93,41 @@ public class AdminServiceImpl implements AdminService {
 
         return ProductOrderDataGroupByCategoryResponse.builder()
             .topCategory(topCategory)
+            .items(items)
+            .build();
+    }
+
+    @Override
+    public MemberPercentageByPhtiResponse fetchMemberPercentageByPhti() {
+
+        List<MemberPercentageByPhtiItem> items = adminMapper.selectMemberPercentageByPhti();
+
+        long totalUsers = items.stream()
+            .mapToLong(MemberPercentageByPhtiItem::users)
+            .sum();
+
+        String topPhti = items.isEmpty() ? "" : items.get(0).type();
+
+        return MemberPercentageByPhtiResponse.builder()
+            .totalUsers(totalUsers)
+            .topPhti(topPhti)
+            .items(items)
+            .build();
+    }
+
+    @Override
+    public IssueAndOrderPatternsByPhtiResponse fetchIssueAndOrderPatternsByPhti() {
+
+        List<IssueAndOrderPatternsByPhtiItem> items = adminMapper.selectIssueAndOrderPatternsByPhti();
+
+        long totalOrders = items.stream()
+            .mapToLong(IssueAndOrderPatternsByPhtiItem::orders)
+            .sum();
+
+        long avgOrders = items.isEmpty() ? 0 : totalOrders / items.size();
+
+        return IssueAndOrderPatternsByPhtiResponse.builder()
+            .avgOrders(avgOrders)
             .items(items)
             .build();
     }

--- a/src/main/resources/mapper/admin/admin_mapper.xml
+++ b/src/main/resources/mapper/admin/admin_mapper.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.phoenix.planet.mapper.AdminMapper">
+    
+    <!-- 에코스톡 발급 비율 -->
+    <select id="selectEcoStockIssuePercentageData"
+        resultType="org.phoenix.planet.dto.admin.eco_stock.IssueItem">
+        SELECT
+        e.name AS name,
+        COUNT(si.stock_issue_id) AS count,
+        ROUND(COUNT(si.stock_issue_id) * 100.0 / SUM(COUNT(si.stock_issue_id)) OVER(), 1) AS value,
+        '#3B82F6' AS color -- TODO: 프론트에서 색상 매핑 가능
+        FROM stock_issue si
+        JOIN eco_stock e ON si.eco_stock_id = e.eco_stock_id
+        WHERE si.status = 'ISSUED'
+        GROUP BY e.name
+        ORDER BY count DESC
+    </select>
+    
+    <!-- 사용자별 에코스톡 보유 현황 -->
+    <select id="selectEcoStockHoldingAmountDataGroupByMember"
+        resultType="org.phoenix.planet.dto.admin.eco_stock.HoldingItem">
+        SELECT range, COUNT(*) AS userCount,
+        ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 1) AS percentage
+        FROM (
+        SELECT
+        CASE
+        WHEN msi.current_total_quantity BETWEEN 1 AND 10 THEN '1-10개'
+        WHEN msi.current_total_quantity BETWEEN 11 AND 50 THEN '11-50개'
+        WHEN msi.current_total_quantity BETWEEN 51 AND 150 THEN '51-150개'
+        WHEN msi.current_total_quantity BETWEEN 151 AND 500 THEN '151-500개'
+        WHEN msi.current_total_quantity BETWEEN 501 AND 1000 THEN '501-1000개'
+        ELSE '1000개 이상'
+        END AS range
+        FROM member_stock_info msi
+        )
+        GROUP BY range
+        ORDER BY range
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/admin/admin_mapper.xml
+++ b/src/main/resources/mapper/admin/admin_mapper.xml
@@ -39,5 +39,31 @@
         GROUP BY range
         ORDER BY range
     </select>
-
+    
+    <!-- 일별 주문/매출 -->
+    <select id="selectProductOrderDataGroupByDay"
+        resultType="org.phoenix.planet.dto.admin.order_product.DayItem">
+        SELECT
+        TO_CHAR(o.created_at, 'YYYY-MM-DD') AS order_date,
+        COUNT(o.order_history_id) AS orders,
+        SUM(o.final_pay_price) AS revenue
+        FROM order_history o
+        WHERE o.order_status IN ('PAID','SHIPPED','COMPLETED')
+        GROUP BY TO_CHAR(o.created_at, 'YYYY-MM-DD')
+        ORDER BY order_date
+    </select>
+    
+    <!-- 카테고리별 판매 비율 -->
+    <select id="selectProductOrderDataGroupByCategory"
+        resultType="org.phoenix.planet.dto.admin.order_product.CategoryItem">
+        SELECT
+        pc.name AS category,
+        SUM(op.price * op.quantity) AS value,
+        '#3B82F6' AS color
+        FROM order_product op
+        JOIN product p ON op.product_id = p.product_id
+        JOIN product_category pc ON p.category_id = pc.category_id
+        GROUP BY pc.name
+        ORDER BY value DESC
+    </select>
 </mapper>

--- a/src/main/resources/mapper/admin/admin_mapper.xml
+++ b/src/main/resources/mapper/admin/admin_mapper.xml
@@ -66,4 +66,29 @@
         GROUP BY pc.name
         ORDER BY value DESC
     </select>
+    
+    <!-- PHTI 사용자 분포 -->
+    <select id="selectMemberPercentageByPhti"
+        resultType="org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiItem">
+        SELECT
+        primary_phti AS type,
+        COUNT(member_id) AS users
+        FROM member_phti
+        GROUP BY primary_phti
+        ORDER BY users DESC
+    </select>
+    
+    <!-- PHTI 주문/교환 패턴 -->
+    <select id="selectIssueAndOrderPatternsByPhti"
+        resultType="org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiItem">
+        SELECT
+        mp.primary_phti AS type,
+        COUNT(DISTINCT oh.order_history_id) AS orders,
+        COUNT(DISTINCT si.stock_issue_id) AS exchanges
+        FROM member_phti mp
+        LEFT JOIN order_history oh ON mp.member_id = oh.member_id
+        LEFT JOIN stock_issue si ON mp.member_id = si.member_id
+        GROUP BY mp.primary_phti
+        ORDER BY type
+    </select>
 </mapper>

--- a/src/main/resources/mapper/admin/admin_mapper.xml
+++ b/src/main/resources/mapper/admin/admin_mapper.xml
@@ -91,4 +91,34 @@
         GROUP BY mp.primary_phti
         ORDER BY type
     </select>
+    
+    <!-- 날짜별 기부 금액 추이 -->
+    <select id="selectDonationAmountsByDay"
+        resultType="org.phoenix.planet.dto.admin.donation.DonationAmountsByDayItem">
+        SELECT
+        TO_CHAR(created_at, 'YYYY-MM-DD') AS order_date,
+        SUM(donation_price) AS donation
+        FROM order_history
+        WHERE donation_price IS NOT NULL
+        GROUP BY TO_CHAR(created_at, 'YYYY-MM-DD')
+        ORDER BY order_date
+    </select>
+    
+    <!-- 사용자별 기부 참여율 -->
+    <select id="selectDonatorPercentage"
+        resultType="org.phoenix.planet.dto.admin.donation.DonatorPercentageItem">
+        SELECT '참여' AS name,
+        COUNT(DISTINCT member_id) AS users,
+        '#10B981' AS color
+        FROM order_history
+        WHERE donation_price > 0
+        
+        UNION ALL
+        
+        SELECT '미참여' AS name,
+        (SELECT COUNT(*) FROM member) -
+        (SELECT COUNT(DISTINCT member_id) FROM order_history WHERE donation_price > 0) AS users,
+        '#EF4444' AS color
+        FROM dual
+    </select>
 </mapper>

--- a/src/main/resources/mapper/admin/admin_mapper.xml
+++ b/src/main/resources/mapper/admin/admin_mapper.xml
@@ -83,11 +83,19 @@
         resultType="org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiItem">
         SELECT
         mp.primary_phti AS type,
-        COUNT(DISTINCT oh.order_history_id) AS orders,
-        COUNT(DISTINCT si.stock_issue_id) AS exchanges
+        SUM(NVL(oh.orders, 0)) AS orders,
+        SUM(NVL(si.exchanges, 0)) AS exchanges
         FROM member_phti mp
-        LEFT JOIN order_history oh ON mp.member_id = oh.member_id
-        LEFT JOIN stock_issue si ON mp.member_id = si.member_id
+        LEFT JOIN (
+        SELECT member_id, COUNT(DISTINCT order_history_id) AS orders
+        FROM order_history
+        GROUP BY member_id
+        ) oh ON mp.member_id = oh.member_id
+        LEFT JOIN (
+        SELECT member_id, COUNT(DISTINCT stock_issue_id) AS exchanges
+        FROM stock_issue
+        GROUP BY member_id
+        ) si ON mp.member_id = si.member_id
         GROUP BY mp.primary_phti
         ORDER BY type
     </select>


### PR DESCRIPTION
### 개요
관리자 통계 대시보드 개발을 위해 필요한 API들을 신규로 추가했습니다.  
에코스톡, 주문/상품, PHTI, 기부 관련 데이터를 수집/가공하여 관리자 페이지에서 시각화할 수 있도록 지원합니다.

### 주요 변경 사항
- **Controller**
  - `AdminController` 신규 추가  
  - 관리자 통계 대시보드 관련 API 엔드포인트 구현
    - `/admin/eco-stock-issue-percentage`
    - `/admin/eco-stock-issue-holdings`
    - `/admin/product-orders-group-by-day`
    - `/admin/product-orders-group-by-category`
    - `/admin/member-percentage-by-phti`
    - `/admin/issue-and-order-patterns-by-phti`
    - `/admin/donation-amounts-by-day`
    - `/admin/donator-percentage`

- **Service**
  - `AdminService`, `AdminServiceImpl` 신규 추가
  - 통계 데이터 가공 로직 구현 (총합, 평균, 비율 계산 등)

- **Mapper**
  - `AdminMapper` 인터페이스 및 `admin_mapper.xml` 작성
  - 에코스톡/주문/상품/PHTI/기부 관련 집계 쿼리 작성

- **DTO**
  - 에코스톡
    - `EcoStockIssuePercentageResponse`, `IssueItem`
    - `EcoStockHoldingAmountGroupByMemberResponse`, `HoldingItem`
  - 주문/상품
    - `ProductOrderDataGroupByDayResponse`, `DayItem`
    - `ProductOrderDataGroupByCategoryResponse`, `CategoryItem`
  - PHTI
    - `MemberPercentageByPhtiResponse`, `MemberPercentageByPhtiItem`
    - `IssueAndOrderPatternsByPhtiResponse`, `IssueAndOrderPatternsByPhtiItem`
  - 기부
    - `DonationAmountsByDayResponse`, `DonationAmountsByDayItem`
    - `DonatorPercentageResponse`, `DonatorPercentageItem`

### 주요 기능
- **에코스톡**
  - 발급 비율 및 총 발급량 조회
  - 사용자별 보유 현황 및 평균 보유량 조회
- **주문/상품**
  - 일별 주문 건수 및 매출 통계
  - 카테고리별 판매 비율 및 Top 카테고리 조회
- **PHTI**
  - 유형별 사용자 분포 및 최다 PHTI 조회
  - 유형별 주문/교환 패턴 및 평균 주문 건수 조회
- **기부**
  - 날짜별 총 기부 금액 추이
  - 사용자별 기부 참여율 및 참여 사용자 수 조회

### 관련 이슈
- SCRUM-159 관리자 통계 대시보드 개발
