### PR TITLE
feat: 멤버 카드 등록/조회/삭제 API 개발

### DIFF
--- a/src/main/java/org/phoenix/planet/controller/MemberController.java
+++ b/src/main/java/org/phoenix/planet/controller/MemberController.java
@@ -12,12 +12,16 @@ import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
 import org.phoenix.planet.dto.member.response.MyOrderResponse;
 import org.phoenix.planet.dto.member.response.MyRaffleResponse;
+import org.phoenix.planet.dto.member_card.MemberCardRegisterRequest;
+import org.phoenix.planet.dto.member_card.MemberCardsInfoResponse;
 import org.phoenix.planet.service.car.MemberCarService;
+import org.phoenix.planet.service.card.MemberCardService;
 import org.phoenix.planet.service.member.MemberService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,6 +37,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final MemberCarService memberCarService;
+    private final MemberCardService memberCardService;
 
     @GetMapping
     public ResponseEntity<List<MemberListResponse>> searchAllMembers() {
@@ -114,5 +119,34 @@ public class MemberController {
 
         System.out.println("여기까지 와요");
         return ResponseEntity.ok(memberService.getMyRaffles(memberId));
+    }
+
+    @GetMapping("/me/cards")
+    public ResponseEntity<MemberCardsInfoResponse> fetchMyCardInfos(
+        @LoginMemberId long loginMemberId
+    ) {
+
+        MemberCardsInfoResponse response = memberCardService.getInfoByMemberId(loginMemberId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/me/cards")
+    public ResponseEntity<Void> registerMyCardInfo(
+        @LoginMemberId long loginMemberId,
+        @RequestBody @Valid MemberCardRegisterRequest request
+    ) {
+
+        memberCardService.registerCardInfo(loginMemberId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/me/cards/{member-card-id}")
+    public ResponseEntity<Void> deleteMyCardInfo(
+        @LoginMemberId long loginMemberId,
+        @PathVariable("member-card-id") long memberCardId
+    ) {
+
+        memberCardService.deleteCardInfo(loginMemberId, memberCardId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/phoenix/planet/dto/member_card/MemberCardInfoItem.java
+++ b/src/main/java/org/phoenix/planet/dto/member_card/MemberCardInfoItem.java
@@ -1,0 +1,10 @@
+package org.phoenix.planet.dto.member_card;
+
+public record MemberCardInfoItem(
+    long memberCardId,
+    long memberCardCompanyId,
+    String memberCardCompanyName,
+    String cardNumber // 카드 번호 (- 미포함)
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/member_card/MemberCardRegisterRequest.java
+++ b/src/main/java/org/phoenix/planet/dto/member_card/MemberCardRegisterRequest.java
@@ -1,0 +1,18 @@
+package org.phoenix.planet.dto.member_card;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MemberCardRegisterRequest(
+    @NotNull(message = "카드사는 필수 선택입니다.")
+    Long cardCompanyId,
+
+    @NotBlank(message = "카드 번호는 필수입니다.")
+    @Size(min = 14, max = 19, message = "카드 번호는 14~19자리여야 합니다.")
+    @Pattern(regexp = "^[0-9]{14,19}$", message = "카드 번호는 숫자만 입력 가능합니다.")
+    String cardNumber // 카드 번호 (- 미포함)
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/member_card/MemberCardsInfoResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/member_card/MemberCardsInfoResponse.java
@@ -1,0 +1,11 @@
+package org.phoenix.planet.dto.member_card;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record MemberCardsInfoResponse(
+    List<MemberCardInfoItem> memberCardInfoList
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/mapper/MemberCardMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberCardMapper.java
@@ -1,13 +1,26 @@
 package org.phoenix.planet.mapper;
 
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.phoenix.planet.dto.member_card.MemberCardInfoItem;
 
 @Mapper
 public interface MemberCardMapper {
+
+    void insertCardInfo(
+        @Param("memberId") long memberId,
+        @Param("cardCompanyId") long cardCompanyId,
+        @Param("cardNumber") String cardNumber);
+
+    void deleteByMemberIdAndMemberCardId(
+        @Param("memberId") long memberId,
+        @Param("memberCardId") long memberCardId);
 
     Long selectMemberIdByCardCompanyIdAndCardNumber(
         @Param("cardCompanyId") Long cardCompanyId,
         @Param("cardNumber") String cardNumber
     );
+
+    List<MemberCardInfoItem> findByMemberId(@Param("memberId") long memberId);
 }

--- a/src/main/java/org/phoenix/planet/service/card/MemberCardService.java
+++ b/src/main/java/org/phoenix/planet/service/card/MemberCardService.java
@@ -1,6 +1,15 @@
 package org.phoenix.planet.service.card;
 
+import org.phoenix.planet.dto.member_card.MemberCardRegisterRequest;
+import org.phoenix.planet.dto.member_card.MemberCardsInfoResponse;
+
 public interface MemberCardService {
 
     Long searchByCardCompanyIdAndCardNumber(Long cardCompanyId, String cardNumber);
+
+    MemberCardsInfoResponse getInfoByMemberId(long memberId);
+
+    void registerCardInfo(long memberId, MemberCardRegisterRequest request);
+
+    void deleteCardInfo(long memberId, long memberCardId);
 }

--- a/src/main/java/org/phoenix/planet/service/card/MemberCardServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/card/MemberCardServiceImpl.java
@@ -1,7 +1,11 @@
 package org.phoenix.planet.service.card;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.phoenix.planet.dto.member_card.MemberCardInfoItem;
+import org.phoenix.planet.dto.member_card.MemberCardRegisterRequest;
+import org.phoenix.planet.dto.member_card.MemberCardsInfoResponse;
 import org.phoenix.planet.mapper.MemberCardMapper;
 import org.springframework.stereotype.Service;
 
@@ -17,5 +21,30 @@ public class MemberCardServiceImpl implements MemberCardService {
 
         return memberCardMapper.selectMemberIdByCardCompanyIdAndCardNumber(cardCompanyId,
             cardNumber);
+    }
+
+    @Override
+    public MemberCardsInfoResponse getInfoByMemberId(long memberId) {
+
+        List<MemberCardInfoItem> items = memberCardMapper.findByMemberId(memberId);
+        
+        return MemberCardsInfoResponse.builder()
+            .memberCardInfoList(items)
+            .build();
+    }
+
+    @Override
+    public void registerCardInfo(long memberId, MemberCardRegisterRequest request) {
+
+        memberCardMapper.insertCardInfo(
+            memberId,
+            request.cardCompanyId(),
+            request.cardNumber());
+    }
+
+    @Override
+    public void deleteCardInfo(long memberId, long memberCardId) {
+
+        memberCardMapper.deleteByMemberIdAndMemberCardId(memberId, memberCardId);
     }
 }

--- a/src/main/resources/mapper/member/member_card_mapper.xml
+++ b/src/main/resources/mapper/member/member_card_mapper.xml
@@ -4,7 +4,32 @@
     "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.phoenix.planet.mapper.MemberCardMapper">
+    <!-- 카드 등록 -->
+    <insert id="insertCardInfo" parameterType="map">
+        <selectKey keyProperty="memberCardId" resultType="long" order="BEFORE">
+            SELECT SEQ_MEMBER_CARD.NEXTVAL FROM DUAL
+        </selectKey>
+        INSERT INTO member_card (
+        member_card_id,
+        member_id,
+        card_company_id,
+        card_number
+        ) VALUES (
+        #{memberCardId},
+        #{memberId},
+        #{cardCompanyId},
+        #{cardNumber}
+        )
+    </insert>
     
+    <!-- 회원이 가진 카드 삭제 -->
+    <delete id="deleteByMemberIdAndMemberCardId" parameterType="map">
+        DELETE FROM member_card
+        WHERE member_id = #{memberId}
+        AND member_card_id = #{memberCardId}
+    </delete>
+    
+    <!-- 카드사ID + 카드번호로 memberId 조회 -->
     <select id="selectMemberIdByCardCompanyIdAndCardNumber"
         parameterType="map"
         resultType="java.lang.Long">
@@ -12,5 +37,21 @@
         FROM member_card mc
         WHERE mc.card_company_id = #{cardCompanyId}
         AND mc.card_number = #{cardNumber}
+    </select>
+    
+    <!-- 특정 회원이 등록한 모든 카드 조회 -->
+    <select id="findByMemberId"
+        parameterType="long"
+        resultType="org.phoenix.planet.dto.member_card.MemberCardInfoItem">
+        SELECT
+        mc.member_card_id AS memberCardId,
+        mc.card_company_id AS memberCardCompanyId,
+        cc.name AS memberCardCompanyName,
+        mc.card_number AS cardNumber
+        FROM member_card mc
+        JOIN card_company cc
+        ON mc.card_company_id = cc.card_company_id
+        WHERE mc.member_id = #{memberId}
+        ORDER BY mc.created_at DESC
     </select>
 </mapper>


### PR DESCRIPTION
### 개요
- 멤버가 자신의 카드를 등록/조회/삭제할 수 있는 API를 새로 추가했습니다.  
- `member_card` 테이블과 `card_company` 테이블을 기반으로 동작합니다 [oai_citation:0‡PLANET_DDL_DML_.txt](file-service://file-Xu1PaLWbeKiRDJcGAmGrf7).  

### 주요 변경 사항
1. **Controller**
   - `MemberController`에 `/me/cards` 관련 API 추가
     - `GET /me/cards`: 내 카드 목록 조회
     - `POST /me/cards`: 카드 등록
     - `DELETE /me/cards/{member-card-id}`: 카드 삭제

2. **DTO**
   - `MemberCardRegisterRequest`: 카드 등록 요청 DTO (Validation 적용)
   - `MemberCardInfoItem`: 조회 응답 아이템 DTO
   - `MemberCardsInfoResponse`: 카드 목록 응답 DTO

3. **Service**
   - `MemberCardService`, `MemberCardServiceImpl` 구현
   - 카드 등록/조회/삭제 비즈니스 로직 추가

4. **Mapper**
   - `MemberCardMapper` 인터페이스 및 MyBatis XML 작성
   - 기능:
     - 카드 등록 (`insertCardInfo`)
     - 카드 삭제 (`deleteByMemberIdAndMemberCardId`)
     - 카드 조회 (`findByMemberId`)
     - 카드사ID+카드번호로 memberId 조회 (`selectMemberIdByCardCompanyIdAndCardNumber`)

5. **DB 매핑**
   - `member_card_mapper.xml` 작성
   - `SEQ_MEMBER_CARD` 시퀀스 기반 `insert` 구현
   - 조인을 통해 카드사 이름까지 함께 조회하도록 구현

### 테스트 시나리오
- [x] 특정 멤버가 등록한 카드 목록 조회 시 `카드사명 + 카드번호` 확인
- [x] 카드 등록 시 유효성 검사 (`14~19자리 숫자`, 카드사 필수 선택)
- [x] 카드 삭제 시 본인 소유 카드만 삭제 가능
- [x] 중복 등록 방지 로직은 `Service`에서 추후 강화 예정
