### PR TITLE
fix/signup: 로컬 회원가입 및 포인트 조회 API 추가

### DIFF
--- a/src/main/java/org/phoenix/planet/configuration/security/SecurityWhitelist.java
+++ b/src/main/java/org/phoenix/planet/configuration/security/SecurityWhitelist.java
@@ -14,6 +14,7 @@ public class SecurityWhitelist {
         "/ws/**",
         "/auth/access-token/regenerate", "/auth/login", "/auth/success",
         "/auth/password-change-mail", "/auth/password-change-token/valid", "/auth/change-password",
+        "/auth/signup/local",
         "/eco-stock/list/**", "/eco-stock/history/**",
         "/department-stores",
         "/eco-products/today", "/eco-products/*",

--- a/src/main/java/org/phoenix/planet/controller/AuthController.java
+++ b/src/main/java/org/phoenix/planet/controller/AuthController.java
@@ -11,11 +11,11 @@ import org.phoenix.planet.configuration.security.CookieProperties;
 import org.phoenix.planet.constant.AuthenticationError;
 import org.phoenix.planet.constant.TokenKey;
 import org.phoenix.planet.dto.auth.PrincipalDetails;
+import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
 import org.phoenix.planet.dto.member.request.LoginRequest;
 import org.phoenix.planet.dto.member.request.PasswordChangeRequest;
 import org.phoenix.planet.dto.member.request.PasswordChangeTokenRequest;
 import org.phoenix.planet.dto.member.request.SendPasswordChangeRequest;
-import org.phoenix.planet.dto.member.request.SignUpRequest;
 import org.phoenix.planet.dto.member.response.LoginResponse;
 import org.phoenix.planet.dto.member.response.SignUpResponse;
 import org.phoenix.planet.service.auth.AuthService;
@@ -50,7 +50,7 @@ public class AuthController {
         produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<SignUpResponse> signUpByKakao(
-        @RequestPart("signUp") @Valid SignUpRequest request,
+        @RequestPart("signUp") @Valid KakaoSignUpRequest request,
         @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
         @LoginMemberId long loginMemberId
     ) {

--- a/src/main/java/org/phoenix/planet/controller/AuthController.java
+++ b/src/main/java/org/phoenix/planet/controller/AuthController.java
@@ -12,6 +12,7 @@ import org.phoenix.planet.constant.AuthenticationError;
 import org.phoenix.planet.constant.TokenKey;
 import org.phoenix.planet.dto.auth.PrincipalDetails;
 import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
+import org.phoenix.planet.dto.member.request.LocalSignUpRequest;
 import org.phoenix.planet.dto.member.request.LoginRequest;
 import org.phoenix.planet.dto.member.request.PasswordChangeRequest;
 import org.phoenix.planet.dto.member.request.PasswordChangeTokenRequest;
@@ -45,14 +46,30 @@ public class AuthController {
     private final CookieProperties cookieProps;
 
     @PostMapping(
+        value = "/signup/local",
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<SignUpResponse> localSignUp(
+        @RequestPart("signUp") @Valid LocalSignUpRequest request,
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) {
+
+        SignUpResponse signUpResponse = memberService.signUp(
+            request,
+            profileImage);
+        return ResponseEntity.ok(signUpResponse);
+    }
+
+    @PostMapping(
         value = "/signup/kakao",
         consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<SignUpResponse> signUpByKakao(
+        @LoginMemberId long loginMemberId,
         @RequestPart("signUp") @Valid KakaoSignUpRequest request,
-        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-        @LoginMemberId long loginMemberId
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
     ) {
 
         SignUpResponse signUpResponse = memberService.signUp(loginMemberId, request, profileImage);

--- a/src/main/java/org/phoenix/planet/controller/MemberController.java
+++ b/src/main/java/org/phoenix/planet/controller/MemberController.java
@@ -8,6 +8,7 @@ import org.phoenix.planet.dto.car.request.CarRegisterRequest;
 import org.phoenix.planet.dto.car.response.MemberCarResponse;
 import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberPointWithHistoriesResponse;
 import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
 import org.phoenix.planet.dto.member.response.MyOrderResponse;
@@ -148,5 +149,15 @@ public class MemberController {
 
         memberCardService.deleteCardInfo(loginMemberId, memberCardId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me/point-histories")
+    public ResponseEntity<MemberPointWithHistoriesResponse> fetchPointHistories(
+        @LoginMemberId long loginMemberId
+    ) {
+
+        MemberPointWithHistoriesResponse response = memberService.fetchPointHistories(
+            loginMemberId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/org/phoenix/planet/dto/admin/eco_stock/IssueItem.java
+++ b/src/main/java/org/phoenix/planet/dto/admin/eco_stock/IssueItem.java
@@ -3,8 +3,7 @@ package org.phoenix.planet.dto.admin.eco_stock;
 public record IssueItem(
     String name,
     int count,
-    double value,   // 비율 (%)
-    String color
+    double value   // 비율 (%)
 ) {
 
 }

--- a/src/main/java/org/phoenix/planet/dto/member/request/KakaoSignUpRequest.java
+++ b/src/main/java/org/phoenix/planet/dto/member/request/KakaoSignUpRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import org.phoenix.planet.constant.Sex;
 
-public record SignUpRequest(
+public record KakaoSignUpRequest(
     @Pattern(
         regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\W).{10,}$",
         message = "비밀번호는 대문자, 소문자, 특수문자를 포함하고 10자 이상이어야 합니다."

--- a/src/main/java/org/phoenix/planet/dto/member/request/LocalSignUpRequest.java
+++ b/src/main/java/org/phoenix/planet/dto/member/request/LocalSignUpRequest.java
@@ -1,0 +1,27 @@
+package org.phoenix.planet.dto.member.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.phoenix.planet.constant.Sex;
+
+public record LocalSignUpRequest(
+    @NotBlank @Email String email,
+    @NotBlank String name,
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\W).{10,}$",
+        message = "비밀번호는 대문자, 소문자, 특수문자를 포함하고 10자 이상이어야 합니다."
+    )
+    @NotBlank String password,
+    @NotNull Sex sex,
+    @Pattern(
+        regexp = "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$",
+        message = "생년월일은 YYYY-MM-DD 형식이어야 합니다."
+    )
+    @NotBlank String birth,
+    @NotBlank String address,
+    @NotBlank String detailAddress
+) {
+
+}

--- a/src/main/java/org/phoenix/planet/dto/member/response/MemberPointWithHistoriesResponse.java
+++ b/src/main/java/org/phoenix/planet/dto/member/response/MemberPointWithHistoriesResponse.java
@@ -1,0 +1,19 @@
+package org.phoenix.planet.dto.member.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberPointWithHistoriesResponse {
+
+    private long memberId;
+    private int currentPoint;
+    private List<PointExchangeHistory> histories;
+
+}

--- a/src/main/java/org/phoenix/planet/dto/member/response/PointExchangeHistory.java
+++ b/src/main/java/org/phoenix/planet/dto/member/response/PointExchangeHistory.java
@@ -1,0 +1,20 @@
+package org.phoenix.planet.dto.member.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PointExchangeHistory {
+
+    long id;
+    int pointPrice;
+    String status;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
+++ b/src/main/java/org/phoenix/planet/mapper/MemberMapper.java
@@ -7,6 +7,7 @@ import org.apache.ibatis.annotations.Param;
 import org.phoenix.planet.constant.Sex;
 import org.phoenix.planet.dto.member.raw.Member;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberPointWithHistoriesResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
 import org.phoenix.planet.dto.member.response.MyOrderResponse;
 import org.phoenix.planet.dto.member.response.MyRaffleResponse;
@@ -48,6 +49,8 @@ public interface MemberMapper {
         @Param("address") String address,
         @Param("detailAddress") String detailAddress);
 
+
+    MemberPointWithHistoriesResponse selectPointWithHistories(@Param("memberId") long memberId);
 
     List<MyOrderResponse> findMyOrders(Long memberId);
 

--- a/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/admin/AdminServiceImpl.java
@@ -20,7 +20,6 @@ import org.phoenix.planet.dto.admin.phti.IssueAndOrderPatternsByPhtiResponse;
 import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiItem;
 import org.phoenix.planet.dto.admin.phti.MemberPercentageByPhtiResponse;
 import org.phoenix.planet.mapper.AdminMapper;
-import org.phoenix.planet.mapper.MemberPhtiMapper;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -29,7 +28,6 @@ import org.springframework.stereotype.Service;
 public class AdminServiceImpl implements AdminService {
 
     private final AdminMapper adminMapper;
-    private final MemberPhtiMapper memberPhtiMapper;
 
     @Override
     public EcoStockIssuePercentageResponse fetchEcoStockIssuePercentageData() {

--- a/src/main/java/org/phoenix/planet/service/member/MemberService.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberService.java
@@ -3,6 +3,7 @@ package org.phoenix.planet.service.member;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
+import org.phoenix.planet.dto.member.request.LocalSignUpRequest;
 import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
 import org.phoenix.planet.dto.member.response.MemberProfileResponse;
@@ -14,7 +15,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
-    SignUpResponse signUp(long loginMemberId, KakaoSignUpRequest request,
+    SignUpResponse signUp(
+        LocalSignUpRequest request,
+        MultipartFile profileImage);
+
+    SignUpResponse signUp(
+        long loginMemberId,
+        KakaoSignUpRequest request,
         MultipartFile profileImage);
 
     List<MemberListResponse> searchAllMembers();

--- a/src/main/java/org/phoenix/planet/service/member/MemberService.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberService.java
@@ -2,8 +2,8 @@ package org.phoenix.planet.service.member;
 
 import jakarta.validation.Valid;
 import java.util.List;
+import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
 import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
-import org.phoenix.planet.dto.member.request.SignUpRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
 import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
@@ -14,7 +14,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
 
-    SignUpResponse signUp(long loginMemberId, SignUpRequest request, MultipartFile profileImage);
+    SignUpResponse signUp(long loginMemberId, KakaoSignUpRequest request,
+        MultipartFile profileImage);
 
     List<MemberListResponse> searchAllMembers();
 
@@ -23,7 +24,7 @@ public interface MemberService {
     MemberProfileResponse searchProfile(long loginMemberId);
 
     void updateMemberInfo(long loginMemberId, @Valid ProfileUpdateRequest profileUpdateRequest,
-            MultipartFile profileImageFile);
+        MultipartFile profileImageFile);
 
     List<MyOrderResponse> getMyOrders(Long memberId);
 

--- a/src/main/java/org/phoenix/planet/service/member/MemberService.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberService.java
@@ -6,6 +6,7 @@ import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
 import org.phoenix.planet.dto.member.request.LocalSignUpRequest;
 import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberPointWithHistoriesResponse;
 import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
 import org.phoenix.planet.dto.member.response.MyOrderResponse;
@@ -38,4 +39,6 @@ public interface MemberService {
     List<MyEcoDealResponse> getMyEcoDeals(Long memberId);
 
     List<MyRaffleResponse> getMyRaffles(Long memberId);
+
+    MemberPointWithHistoriesResponse fetchPointHistories(long memberId);
 }

--- a/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
@@ -3,8 +3,8 @@ package org.phoenix.planet.service.member;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.phoenix.planet.dto.member.raw.Member;
+import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
 import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
-import org.phoenix.planet.dto.member.request.SignUpRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
 import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
@@ -86,7 +86,7 @@ public class MemberServiceImpl implements MemberService {
     @Transactional
     public SignUpResponse signUp(
         long loginMemberId,
-        SignUpRequest request,
+        KakaoSignUpRequest request,
         MultipartFile profileImage) {
 
         // 패스워드 해시화

--- a/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
+++ b/src/main/java/org/phoenix/planet/service/member/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import org.phoenix.planet.dto.member.request.KakaoSignUpRequest;
 import org.phoenix.planet.dto.member.request.LocalSignUpRequest;
 import org.phoenix.planet.dto.member.request.ProfileUpdateRequest;
 import org.phoenix.planet.dto.member.response.MemberListResponse;
+import org.phoenix.planet.dto.member.response.MemberPointWithHistoriesResponse;
 import org.phoenix.planet.dto.member.response.MemberProfileResponse;
 import org.phoenix.planet.dto.member.response.MyEcoDealResponse;
 import org.phoenix.planet.dto.member.response.MyOrderResponse;
@@ -189,5 +190,11 @@ public class MemberServiceImpl implements MemberService {
     public List<MyRaffleResponse> getMyRaffles(Long memberId) {
 
         return memberMapper.getMyRaffles(memberId);
+    }
+
+    @Override
+    public MemberPointWithHistoriesResponse fetchPointHistories(long memberId) {
+
+        return memberMapper.selectPointWithHistories(memberId);
     }
 }

--- a/src/main/resources/mapper/admin/admin_mapper.xml
+++ b/src/main/resources/mapper/admin/admin_mapper.xml
@@ -10,8 +10,7 @@
         SELECT
         e.name AS name,
         COUNT(si.stock_issue_id) AS count,
-        ROUND(COUNT(si.stock_issue_id) * 100.0 / SUM(COUNT(si.stock_issue_id)) OVER(), 1) AS value,
-        '#3B82F6' AS color -- TODO: 프론트에서 색상 매핑 가능
+        ROUND(COUNT(si.stock_issue_id) * 100.0 / SUM(COUNT(si.stock_issue_id)) OVER(), 1) AS value
         FROM stock_issue si
         JOIN eco_stock e ON si.eco_stock_id = e.eco_stock_id
         WHERE si.status = 'ISSUED'

--- a/src/main/resources/mapper/member/member_mapper.xml
+++ b/src/main/resources/mapper/member/member_mapper.xml
@@ -150,6 +150,41 @@
         WHERE role = 'USER'
     </select>
     
+    <resultMap id="PointWithHistoriesResultMap"
+        type="org.phoenix.planet.dto.member.response.MemberPointWithHistoriesResponse">
+        <id column="member_id" property="memberId"/>
+        <result column="point" property="currentPoint"/>
+        <collection property="histories"
+            ofType="org.phoenix.planet.dto.member.response.PointExchangeHistory"
+            javaType="java.util.List">
+            <id column="point_exchange_history_id" property="id"/>
+            <result column="point_price" property="pointPrice" jdbcType="NUMERIC" javaType="int"/>
+            <result column="status" property="status"/>
+            <result column="created_at" property="createdAt" jdbcType="TIMESTAMP"
+                javaType="java.time.LocalDateTime"/>
+            <result column="updated_at" property="updatedAt" jdbcType="TIMESTAMP"
+                javaType="java.time.LocalDateTime"/>
+        </collection>
+    </resultMap>
+    
+    <select id="selectPointWithHistories" parameterType="long"
+        resultMap="PointWithHistoriesResultMap">
+        SELECT
+        m.member_id,
+        m.point,
+        peh.point_exchange_history_id,
+        point_price,
+        peh.status,
+        peh.created_at,
+        peh.updated_at
+        FROM member m
+        LEFT JOIN point_exchange_history peh
+        ON m.member_id = peh.member_id
+        WHERE m.member_id = #{memberId}
+        ORDER BY peh.created_at DESC
+    </select>
+    
+    
     <!-- 포인트 차감 -->
     <update id="deductPointsByMemberId">
         UPDATE member

--- a/src/main/resources/sql/ddl/1_ECO_STOCK.sql
+++ b/src/main/resources/sql/ddl/1_ECO_STOCK.sql
@@ -29,10 +29,10 @@ INSERT INTO eco_stock (eco_stock_id, name, quantity, image_url, created_at, upda
 VALUES (4, '제로백(Bag)', 100, null, SYSDATE, NULL);
 
 INSERT INTO eco_stock (eco_stock_id, name, quantity, image_url, created_at, updated_at)
-VALUES (5, '봉시활동', 1000, null, SYSDATE, NULL);
+VALUES (5, '봉사활동', 1000, null, SYSDATE, NULL);
 
 INSERT INTO eco_stock (eco_stock_id, name, quantity, image_url, created_at, updated_at)
-VALUES (6, '기부온(Give_On)', 100, null, SYSDATE, NULL);
+VALUES (6, '기부온(Give On)', 100, null, SYSDATE, NULL);
 
 COMMIT;
 


### PR DESCRIPTION
## PR 설명
이번 PR에서는 **회원가입 로직 분리 및 포인트 관리 기능**을 중심으로 백엔드 기능을 개선했습니다.  
프론트엔드 변경 사항(로컬 회원가입 페이지, 포인트 기록 조회) [oai_citation:0‡planet-project-info.txt](file-service://file-NHivce2wXj2ZHwJpQ2CqvX) [oai_citation:1‡PLANET_DDL_DML_.txt](file-service://file-Xu1PaLWbeKiRDJcGAmGrf7)과 연계되는 API를 제공합니다.

---

### 주요 변경 사항
1. **회원가입 API 개선**
   - 기존 `SignUpRequest` → `KakaoSignUpRequest`로 리네이밍
   - `LocalSignUpRequest` 신규 추가 (이메일/비밀번호 기반 회원가입)
   - `AuthController`에 `/auth/signup/local` 엔드포인트 추가 (멀티파트 FormData + 프로필 이미지 업로드 지원)
   - `MemberService`/`MemberServiceImpl`에 `signUp(LocalSignUpRequest, MultipartFile)` 구현
   - 로컬 회원가입 시 비밀번호 해싱 및 S3 프로필 업로드 반영

2. **포인트 관리 API**
   - `MemberController`에 `/members/me/point-histories` API 추가
   - `MemberPointWithHistoriesResponse`, `PointExchangeHistory` DTO 추가
   - `member_mapper.xml`에 `PointWithHistoriesResultMap` 및 `selectPointWithHistories` 쿼리 추가
   - 현재 보유 포인트(`member.point`)와 교환/적립 내역(`point_exchange_history`) 조회 가능

3. **에코스톡 관련 수정**
   - `IssueItem` DTO에서 color 제거 (프론트에서 팔레트 매핑)
   - `admin_mapper.xml` 쿼리에서 color 컬럼 제거
   - 초기 데이터 `1_ECO_STOCK.sql`에서 잘못된 이름 수정 (`봉시활동 → 봉사활동`, `기부온(Give_On) → 기부온(Give On)`)

4. **보안 설정**
   - `/auth/signup/local` 엔드포인트 SecurityWhitelist에 추가

---

### 스키마 반영 사항
- `member` 테이블에 `point NUMBER DEFAULT 0 NOT NULL` 컬럼 존재 [oai_citation:2‡PLANET_DDL_DML_.txt](file-service://file-Xu1PaLWbeKiRDJcGAmGrf7)  
- `point_exchange_history`와 연계하여 보유 포인트 + 내역 조회 API에서 활용  

---

### 테스트 방법
1. **로컬 회원가입**
   ```http
   POST /auth/signup/local
   Content-Type: multipart/form-data
   Body:
     - signUp: { email, name, password, sex, birth, address, detailAddress }
     - profileImage: (optional)